### PR TITLE
Integrate ReactJS connection with backend routing

### DIFF
--- a/front-runner/package.json
+++ b/front-runner/package.json
@@ -2,6 +2,7 @@
   "name": "front-runner",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8080",
   "dependencies": {
     "cra-template": "1.2.0",
     "react": "^19.0.0",

--- a/front-runner_backend/internal/login/login.go
+++ b/front-runner_backend/internal/login/login.go
@@ -59,7 +59,7 @@ func init() {
 // @Success      200 {string} string "Logged in successfully."
 // @Failure      400 {string} string "Email and password are required"
 // @Failure      401 {string} string "Invalid credentials"
-// @Router       /login [post]
+// @Router       /api/login [post]
 func LoginUser(w http.ResponseWriter, r *http.Request) {
 	// Retrieve the session first.
 	session, err := sessionStore.Get(r, "auth")
@@ -114,7 +114,7 @@ func LoginUser(w http.ResponseWriter, r *http.Request) {
 // @Tags         authentication, logout
 // @Produce      plain
 // @Success      200 {string} string "Logged out successfully"
-// @Router       /logout [get]
+// @Router       /api/logout [get]
 func LogoutUser(w http.ResponseWriter, r *http.Request) {
 	session, err := sessionStore.Get(r, "auth")
 	if err != nil {

--- a/front-runner_backend/internal/usertable/usertable.go
+++ b/front-runner_backend/internal/usertable/usertable.go
@@ -61,7 +61,7 @@ func ClearUserTable(db *gorm.DB) error {
 // @Success      200 {string} string "User registered successfully"
 // @Failure      400 {string} string "Email and password are required or invalid email format"
 // @Failure      409 {string} string "Email already in use or database error"
-// @Router       /register [post]
+// @Router       /api/register [post]
 func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	email := r.FormValue("email")
 	password := r.FormValue("password")

--- a/front-runner_backend/internal/validemail/validemail.go
+++ b/front-runner_backend/internal/validemail/validemail.go
@@ -10,7 +10,7 @@ import "net/mail"
 // @Tags         utility, email, validate
 // @Param        email query string true "Email address to validate"
 // @Success      200 {boolean} boolean "true if email is valid, false otherwise"
-// @Router       /validemail [get]
+// @Router       /api/validemail [get]
 func Valid(email string) bool {
 	_, err := mail.ParseAddress(email)
 	return err == nil


### PR DESCRIPTION
- Connect golang backend with ReactJs frontend.
- Update API endpoints to differentiate from web page listings.
- Update UI package.json to include proxy to go server. Allows local development of interface while routing api calls to backend.

Closes #29.