### PR TITLE
Product Name Unique Constraint Fix

### DIFF
--- a/front-runner_backend/internal/prodtable/prodtable.go
+++ b/front-runner_backend/internal/prodtable/prodtable.go
@@ -26,8 +26,8 @@ type Image struct {
 
 type Product struct {
 	ID              uint   `gorm:"primaryKey"`
-	UserID          uint   `gorm:"not null;index"`
-	ProdName        string `gorm:"unique;not null"`
+	UserID          uint   `gorm:"not null;index:idx_product,unique"`
+	ProdName        string `gorm:"not null;index:idx_product,unique"`
 	ProdDescription string `gorm:"not null"`
 	ImgID           uint
 	Img             Image `gorm:"foreignKey:ImgID"`


### PR DESCRIPTION
Fixes issue where two users cannot have the same product name. Still enforces constraint per-user.

Closes #57.