### PR TITLE
Storefronts

### DIFF
--- a/front-runner/src/components/Home.js
+++ b/front-runner/src/components/Home.js
@@ -21,6 +21,14 @@ const Home = () => {
         { order: "0007", product: "Product 7", quantity: 1, total: "$15.75", customer: "Customer 7" },
     ]);
 
+    const [colDefs, setColDefs] = useState([
+        { field: "order" },
+        { field: "product" },
+        { field: "quantity" },
+        { field: "total" },
+        { field: "customer" }
+    ]);
+
     const [products, setProducts] = useState([]);
 
     useEffect(() => {
@@ -37,13 +45,30 @@ const Home = () => {
         fetchProducts();
     }, []);
 
-    const [colDefs, setColDefs] = useState([
-        { field: "order" },
-        { field: "product" },
-        { field: "quantity" },
-        { field: "total" },
-        { field: "customer" }
-    ]);
+    const [storefronts, setStorefronts] = useState([]);
+
+    useEffect(() => {
+        const fetchStorefronts = async () => {
+            try {
+                const response = await fetch('/api/get_storefronts'); // API endpoint
+                if (!response.ok) {
+                     if (response.status === 401) {
+                        console.log("User not authenticated to fetch storefronts.");
+                        setStorefronts([]);
+                        return;
+                    }
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                const data = await response.json();
+                // Slice to first 3 to match existing CSS layout for now
+                setStorefronts(data ? data.slice(0, 3) : []);
+            } catch (error) {
+                console.error('Error fetching storefronts:', error);
+                setStorefronts([]);
+            }
+        };
+        fetchStorefronts();
+    }, []);
 
     return (
         <div className='home'>
@@ -150,7 +175,7 @@ const Home = () => {
                             </div>
 
                         </div>
-                        <div className='small-home-tile storefronts-small-home-tile'>
+                        {/* <div className='small-home-tile storefronts-small-home-tile'>
                             <div className='tile-header'>
                                 <h2>My Storefronts</h2>
                                 <div className='view-all-products' onClick={() => window.location.href='/storefronts'}>
@@ -170,6 +195,45 @@ const Home = () => {
                                 <div className='home-storefront'>
                                     <h3>Storefront 2</h3>
                                 </div>
+                            </div>
+                        </div> */}
+                        {/* --- Storefronts Tile (MODIFIED) --- */}
+                        <div className='small-home-tile storefronts-small-home-tile'>
+                            <div className='tile-header'>
+                                <h2>My Storefronts</h2>
+                                <div className='view-all-products' onClick={() => window.location.href = '/storefronts'}>
+                                    <p>View all</p>
+                                     {/* Arrow SVG */}
+                                    <svg width="26" height="24" viewBox="0 0 26 24" fill="none" xmlns="http://www.w3.org/2000/svg" className='arrow-right'>
+                                        <path d="M25.0607 13.0607C25.6464 12.4749 25.6464 11.5251 25.0607 10.9393L15.5147 1.3934C14.9289 0.807612 13.9792 0.807612 13.3934 1.3934C12.8076 1.97918 12.8076 2.92893 13.3934 3.51472L21.8787 12L13.3934 20.4853C12.8076 21.0711 12.8076 22.0208 13.3934 22.6066C13.9792 23.1924 14.9289 23.1924 15.5147 22.6066L25.0607 13.0607ZM0 13.5H24V10.5H0L0 13.5Z" fill="white" />
+                                    </svg>
+                                </div>
+                            </div>
+                            {/* --- Dynamic Storefront Rendering --- */}
+                            <div className='storefront-tiles'>
+                                {storefronts.length === 0 ? (
+                                    // Placeholder when no storefronts are linked
+                                     <p style={{ /* Placeholder styles */
+                                        width: '90%', position: 'absolute', textAlign: 'center',
+                                        top: '50%', left: '50%', transform: 'translate(-50%, -50%)',
+                                        fontStyle: 'italic', color: 'gray'
+                                    }}>
+                                        No storefronts linked yet. <a href='/storefronts' style={{ /* Link styles */
+                                            textDecoration: 'underline', background: 'linear-gradient(to right, #FF4949, #FF8000)',
+                                            backgroundClip: 'text', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent',
+                                            borderBottom: '1px solid #FF4949'
+                                        }}>Link one</a>.
+                                    </p>
+                                ) : (
+                                    // Map over the fetched storefronts
+                                    storefronts.map((storefront) => (
+                                        <div className='home-storefront' key={storefront.id}>
+                                            {/* Display the storefront name or type */}
+                                            {/* Make sure 'storeName' and 'storeType' match your API response fields */}
+                                            <h3>{storefront.storeName || storefront.storeType}</h3>
+                                        </div>
+                                    ))
+                                )}
                             </div>
                         </div>
                     </div>

--- a/front-runner/src/components/StorefrontLinkForm.css
+++ b/front-runner/src/components/StorefrontLinkForm.css
@@ -1,0 +1,172 @@
+/* StorefrontLinkForm.css - Dark Theme Adaptation */
+
+/* Style the modal backdrop - equivalent to add-product-container */
+.modal-backdrop {
+    z-index: 1000; /* Ensure it's on top */
+    position: fixed; /* Use fixed to cover viewport */
+    top: 0;
+    left: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: white; /* Default text color for anything directly in backdrop (unlikely) */
+    background-color: rgba(11, 11, 11, 0.85); /* Dark semi-transparent background like #0b0b0b */
+    height: 100%;
+    width: 100%; /* Use 100% instead of 100vw for fixed positioning */
+    overflow-y: auto; /* Allow backdrop scrolling if modal is very tall */
+}
+
+/* Style the modal content area - equivalent to add-product-card */
+.modal-content.storefront-form {
+    width: 40%; /* Match product card width */
+    min-width: 400px; /* Match product card min-width */
+    max-width: 600px; /* Added max-width for larger screens */
+    padding: 25px; /* Slightly adjust padding */
+    border: 1px solid rgba(255, 255, 255, 0.25); /* Match product card border */
+    border-radius: 10px; /* Match product card border-radius */
+    color: white; /* Match product card text color */
+    background-color: #181818; /* Match product card background */
+    display: flex; /* Use flex for internal layout */
+    flex-direction: column; /* Stack elements vertically */
+    position: relative; /* For positioning the close button */
+    max-height: 90vh; /* Limit height */
+    /* Removed overflow-y: auto; from here, handled by backdrop if needed */
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3); /* Optional shadow for depth */
+}
+
+/* --- Header --- */
+.modal-content.storefront-form h2 {
+    font-size: 1.5rem; /* Match product form header */
+    margin-top: 0;
+    margin-bottom: 25px; /* Increased spacing */
+    text-align: left; /* Align title left */
+    /* Optional: Add flex if you want something next to the title */
+}
+
+.modal-close-button {
+    position: absolute;
+    top: 15px; /* Adjust position */
+    right: 15px; /* Adjust position */
+    background: none;
+    border: none;
+    font-size: 1.5rem; /* Make it easily clickable */
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.7); /* Lighter gray for visibility */
+    padding: 5px;
+    line-height: 1; /* Ensure consistent alignment */
+}
+.modal-close-button:hover {
+    color: white; /* Brighten on hover */
+}
+
+
+/* --- Form Styling --- */
+.storefront-form .form-group {
+    margin-bottom: 15px;
+}
+
+.storefront-form label {
+    display: block;
+    margin-bottom: 8px; /* Slightly more space */
+    font-weight: bold;
+    color: rgba(255, 255, 255, 0.8); /* Slightly softer white */
+    font-size: 0.95rem;
+}
+
+/* Style inputs and select like .form-control */
+.storefront-form input[type="text"],
+.storefront-form input[type="password"],
+.storefront-form input[type="url"],
+.storefront-form select {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid rgba(255, 255, 255, 0.25); /* Subtle border */
+    border-radius: 5px; /* Slightly rounded */
+    box-sizing: border-box;
+    background-color: #2a2a2a; /* Darker input background */
+    color: white; /* White text in inputs */
+    font-size: 1rem;
+}
+
+.storefront-form input::placeholder { /* Style placeholder text */
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.storefront-form select {
+    /* Specific styling for select dropdown arrow might be needed */
+    appearance: none; /* Basic reset */
+     /* Add custom arrow background image if desired */
+    background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23BBB%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E');
+    background-repeat: no-repeat;
+    background-position: right 10px top 50%;
+    background-size: 10px auto;
+    padding-right: 30px; /* Make space for arrow */
+}
+
+/* Focus styles */
+.storefront-form input:focus,
+.storefront-form select:focus {
+    outline: none;
+    border-color: rgba(255, 128, 0, 0.7); /* Highlight with theme color */
+    box-shadow: 0 0 0 2px rgba(255, 128, 0, 0.3); /* Subtle glow */
+}
+
+/* --- Error Message --- */
+.storefront-form .form-error {
+    color: #FF4949; /* Use theme red */
+    background-color: rgba(255, 73, 73, 0.1); /* Subtle red background */
+    border: 1px solid rgba(255, 73, 73, 0.5);
+    border-radius: 4px;
+    padding: 10px;
+    margin-bottom: 15px;
+    text-align: center;
+    font-size: 0.9em;
+}
+
+/* --- Form Actions / Buttons --- */
+.storefront-form .form-actions {
+    display: flex;
+    justify-content: flex-end; /* Align buttons right */
+    gap: 15px; /* Space between buttons */
+    margin-top: 25px; /* Space above buttons */
+    width: 100%; /* Ensure it takes full width */
+}
+
+.storefront-form button {
+    padding: 10px 25px; /* Adjust padding */
+    border: none;
+    border-radius: 5px; /* Match input radius */
+    cursor: pointer;
+    font-size: 1rem; /* Match input font size */
+    font-weight: bold;
+    transition: background 0.3s ease, opacity 0.3s ease;
+}
+
+/* Submit Button - Style like .btn-info */
+.storefront-form button[type="submit"] {
+    background: linear-gradient(to right, #FF4949, #FF8000); /* Match gradient */
+    color: white;
+}
+.storefront-form button[type="submit"]:hover {
+    opacity: 0.9; /* Slight fade on hover */
+}
+.storefront-form button[type="submit"]:disabled {
+    background: linear-gradient(to right, #a53232, #a05300); /* Darker gradient when disabled */
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+/* Cancel Button - Subtle style */
+.storefront-form button[type="button"] {
+    background-color: #444; /* Dark grey */
+    color: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.2); /* Subtle border */
+}
+.storefront-form button[type="button"]:hover {
+    background-color: #555; /* Slightly lighter grey on hover */
+}
+.storefront-form button[type="button"]:disabled {
+    background-color: #333;
+    opacity: 0.6;
+    cursor: not-allowed;
+}

--- a/front-runner/src/components/StorefrontLinkForm.css
+++ b/front-runner/src/components/StorefrontLinkForm.css
@@ -170,3 +170,46 @@
     opacity: 0.6;
     cursor: not-allowed;
 }
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end; /* Align main buttons to the right */
+    gap: 10px;
+    margin-top: 20px;
+    width: 100%;
+}
+
+/* Style for the delete button */
+.delete-button {
+    /* Position delete button on the left */
+    margin-right: auto;
+
+    /* Styling for destructive action */
+    background-color: transparent; /* Or a subtle dark red background */
+    color: #FF4949; /* Theme red color */
+    border: 1px solid #FF4949;
+    padding: 10px 20px; /* Match other buttons */
+    border-radius: 4px; /* Match other buttons */
+    cursor: pointer;
+    font-weight: bold; /* Match other buttons */
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.delete-button:hover {
+    background-color: rgba(255, 73, 73, 0.1); /* Subtle red background on hover */
+    color: #ff6f6f; /* Lighter red on hover */
+}
+
+.delete-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background-color: transparent; /* Keep transparent */
+    color: #a53232; /* Darker red when disabled */
+    border-color: #a53232;
+}
+
+/* Ensure other buttons stay on the right */
+/* .form-actions button[type="button"]:not(.delete-button),
+.form-actions button[type="submit"] {
+     /* No changes needed if using justify-content: flex-end and margin-right: auto on delete */
+/* } */ 

--- a/front-runner/src/components/StorefrontLinkForm.js
+++ b/front-runner/src/components/StorefrontLinkForm.js
@@ -1,0 +1,202 @@
+import React, { useState, useEffect } from 'react';
+import './StorefrontLinkForm.css'; // We'll need to create this CSS file
+
+// Define supported storefront types
+const SUPPORTED_STOREFRONTS = [
+    { value: 'amazon', label: 'Amazon Seller Central' },
+    { value: 'pinterest', label: 'Pinterest Business' },
+    { value: 'etsy', label: 'Etsy' },
+    // Add more as you support them
+];
+
+const StorefrontLinkForm = ({ storefront, onClose, onSubmitSuccess }) => {
+    // Determine if we are editing or adding new
+    const isEditing = storefront !== null;
+    const formTitle = isEditing ? 'Edit Storefront Link' : 'Link New Storefront';
+
+    // --- State for Form Fields ---
+    // Initialize state based on whether we are editing or adding
+    const [storeType, setStoreType] = useState(storefront?.storeType || SUPPORTED_STOREFRONTS[0]?.value || ''); // Default to first option or empty
+    const [storeName, setStoreName] = useState(storefront?.storeName || ''); // User-defined name for the link
+    const [apiKey, setApiKey] = useState(''); // Sensitive - will be sent to backend
+    const [apiSecret, setApiSecret] = useState(''); // Sensitive - will be sent to backend
+    const [storeId, setStoreId] = useState(storefront?.storeId || ''); // Platform specific ID (e.g., Amazon Seller ID)
+    const [storeUrl, setStoreUrl] = useState(storefront?.storeUrl || ''); // Optional URL
+
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState('');
+
+    // --- TODO: Dynamic Fields (Optional Advanced Feature) ---
+    // In a real-world scenario, different store types require different fields.
+    // You might dynamically render fields based on the selected 'storeType'.
+    // For now, we'll include a few common ones. Adjust as needed per platform.
+
+    // --- Handle Form Submission ---
+    const handleSubmit = async (event) => {
+        event.preventDefault();
+        setIsLoading(true);
+        setError('');
+
+        // Basic validation
+        if (!storeType) {
+             setError('Please select a storefront type.');
+             setIsLoading(false);
+             return;
+        }
+        // Add more validation as needed (e.g., check required fields based on storeType)
+
+        // Prepare data payload for the backend
+        // IMPORTANT: Only send necessary fields. Sensitive data like keys/secrets
+        // should be handled securely by the backend (e.g., encryption).
+        const payload = {
+            storeType,
+            storeName: storeName || `${storeType} Link`, // Default name if empty
+            // --- Include credentials ONLY for the ADD request ---
+            // For UPDATE, you might handle credential changes differently or not allow updates via form
+            apiKey: isEditing ? undefined : apiKey, // Only send on add, or if specifically changed
+            apiSecret: isEditing ? undefined : apiSecret, // Only send on add, or if specifically changed
+            storeId,
+            storeUrl,
+            // If editing, include the ID of the storefront being edited
+            id: isEditing ? storefront.id : undefined,
+        };
+
+        // Determine API endpoint and method
+        const apiUrl = isEditing ? `/api/update_storefront?id=${storefront.id}` : '/api/add_storefront';
+        const apiMethod = isEditing ? 'PUT' : 'POST';
+
+        try {
+            const response = await fetch(apiUrl, {
+                method: apiMethod,
+                headers: {
+                    'Content-Type': 'application/json',
+                    // Add authorization headers if needed (e.g., JWT token)
+                    // 'Authorization': `Bearer ${your_token}`
+                },
+                body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+                 const errorData = await response.text(); // Get error details from backend
+                 throw new Error(errorData || `Failed to ${isEditing ? 'update' : 'add'} storefront`);
+            }
+
+            // Success!
+            onSubmitSuccess(); // Call the success handler passed from parent
+
+        } catch (err) {
+            console.error("Form submission error:", err);
+            setError(err.message || `An error occurred.`);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    // --- Render Modal Form ---
+    return (
+        <div className="modal-backdrop"> {/* Style this to cover the background */}
+            <div className="modal-content storefront-form"> {/* Style the modal container */}
+                <h2>{formTitle}</h2>
+                <button className="modal-close-button" onClick={onClose}>X</button>
+
+                <form onSubmit={handleSubmit}>
+                    {error && <p className="form-error">{error}</p>}
+
+                    {/* Store Type Dropdown */}
+                    <div className="form-group">
+                        <label htmlFor="storeType">Storefront Type *</label>
+                        <select
+                            id="storeType"
+                            value={storeType}
+                            onChange={(e) => setStoreType(e.target.value)}
+                            required
+                            disabled={isEditing} // Usually can't change type after creation
+                        >
+                            <option value="" disabled>Select a type...</option>
+                            {SUPPORTED_STOREFRONTS.map(option => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                     {/* Store Name (Optional Nickname) */}
+                     <div className="form-group">
+                        <label htmlFor="storeName">Link Name (Optional)</label>
+                        <input
+                            type="text"
+                            id="storeName"
+                            value={storeName}
+                            onChange={(e) => setStoreName(e.target.value)}
+                            placeholder="e.g., My Primary Amazon Store"
+                        />
+                    </div>
+
+                    {/* --- Fields specific to ADDING (Credentials) --- */}
+                    {!isEditing && (
+                         <>
+                            <div className="form-group">
+                                <label htmlFor="apiKey">API Key *</label>
+                                <input
+                                    type="password" // Use password type for sensitive fields
+                                    id="apiKey"
+                                    value={apiKey}
+                                    onChange={(e) => setApiKey(e.target.value)}
+                                    required
+                                    placeholder="Enter API Key from store"
+                                />
+                            </div>
+                             <div className="form-group">
+                                <label htmlFor="apiSecret">API Secret / Token *</label>
+                                <input
+                                    type="password" // Use password type
+                                    id="apiSecret"
+                                    value={apiSecret}
+                                    onChange={(e) => setApiSecret(e.target.value)}
+                                    required
+                                    placeholder="Enter API Secret or Token"
+                                />
+                             </div>
+                         </>
+                    )}
+                     {/* --- Fields common to ADD/EDIT (or specific types) --- */}
+                    {/* Example: Store ID (Adjust label based on selected storeType if needed) */}
+                    <div className="form-group">
+                        <label htmlFor="storeId">Store ID / Seller ID</label>
+                        <input
+                            type="text"
+                            id="storeId"
+                            value={storeId}
+                            onChange={(e) => setStoreId(e.target.value)}
+                            placeholder="e.g., A1B2C3D4E5F6G7 (Amazon)"
+                        />
+                    </div>
+
+                    {/* Example: Store URL (Optional) */}
+                     <div className="form-group">
+                        <label htmlFor="storeUrl">Store URL (Optional)</label>
+                        <input
+                            type="url"
+                            id="storeUrl"
+                            value={storeUrl}
+                            onChange={(e) => setStoreUrl(e.target.value)}
+                            placeholder="e.g., https://www.amazon.com/yourstore"
+                        />
+                     </div>
+
+
+                    {/* Form Actions */}
+                    <div className="form-actions">
+                        <button type="button" onClick={onClose} disabled={isLoading}>Cancel</button>
+                        <button type="submit" disabled={isLoading}>
+                            {isLoading ? 'Saving...' : (isEditing ? 'Update Link' : 'Link Storefront')}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default StorefrontLinkForm;

--- a/front-runner/src/components/StorefrontLinkForm.js
+++ b/front-runner/src/components/StorefrontLinkForm.js
@@ -10,231 +10,212 @@ const SUPPORTED_STOREFRONTS = [
 ];
 
 const StorefrontLinkForm = ({ storefront, onClose, onSubmitSuccess }) => {
-    // Determine if we are editing or adding new
     const isEditing = storefront !== null;
     const formTitle = isEditing ? 'Edit Storefront Link' : 'Link New Storefront';
 
-    // --- State for Form Fields ---
-    // Initialize state based on whether we are editing or adding
-    // These initializations correctly handle pre-filling form for editing
     const [storeType, setStoreType] = useState(storefront?.storeType || SUPPORTED_STOREFRONTS[0]?.value || '');
     const [storeName, setStoreName] = useState(storefront?.storeName || '');
-    const [apiKey, setApiKey] = useState(''); // Only used for adding
-    const [apiSecret, setApiSecret] = useState(''); // Only used for adding
+    const [apiKey, setApiKey] = useState('');
+    const [apiSecret, setApiSecret] = useState('');
     const [storeId, setStoreId] = useState(storefront?.storeId || '');
     const [storeUrl, setStoreUrl] = useState(storefront?.storeUrl || '');
 
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState('');
 
-    // Effect to reset API key/secret fields if the mode changes (optional cleanup)
     useEffect(() => {
         if (isEditing) {
             setApiKey('');
             setApiSecret('');
         }
-         // Reset fields if the passed storefront prop changes (e.g. closing and reopening modal for different item)
-         setStoreType(storefront?.storeType || SUPPORTED_STOREFRONTS[0]?.value || '');
-         setStoreName(storefront?.storeName || '');
-         setStoreId(storefront?.storeId || '');
-         setStoreUrl(storefront?.storeUrl || '');
-         setError(''); // Clear errors when modal opens/changes mode
+        setStoreType(storefront?.storeType || SUPPORTED_STOREFRONTS[0]?.value || '');
+        setStoreName(storefront?.storeName || '');
+        setStoreId(storefront?.storeId || '');
+        setStoreUrl(storefront?.storeUrl || '');
+        setError('');
+    }, [storefront, isEditing]);
 
-    }, [storefront, isEditing]); // Rerun when storefront prop changes
-
-
-    // --- MODIFIED: Handle Form Submission ---
     const handleSubmit = async (event) => {
         event.preventDefault();
         setIsLoading(true);
         setError('');
 
-        // Basic validation (remains the same)
         if (!storeType) {
-             setError('Please select a storefront type.');
-             setIsLoading(false);
-             return;
+            setError('Please select a storefront type.');
+            setIsLoading(false);
+            return;
         }
-        // Add more validation if needed...
-        // Example: Require API key/secret only when adding
         if (!isEditing && (apiKey === '' || apiSecret === '')) {
-             setError('API Key and Secret are required when linking a new storefront.');
-             setIsLoading(false);
-             return;
+            setError('API Key and Secret are required when linking a new storefront.');
+            setIsLoading(false);
+            return;
         }
 
-
-        // --- Prepare Payload based on mode ---
         let payload = {};
         let apiUrl = '';
         let apiMethod = '';
 
         if (isEditing) {
-            // --- EDITING MODE ---
             apiMethod = 'PUT';
             apiUrl = `/api/update_storefront?id=${storefront.id}`;
             payload = {
-                // Fields allowed in the StorefrontLinkUpdatePayload (Go backend)
-                storeName: storeName || `${storefront.storeType} Link`, // Default name if cleared
+                storeName: storeName || `${storefront.storeType} Link`,
                 storeId: storeId,
                 storeUrl: storeUrl,
-                // DO NOT send storeType, apiKey, apiSecret for update
             };
         } else {
-            // --- ADDING MODE ---
             apiMethod = 'POST';
             apiUrl = '/api/add_storefront';
             payload = {
-                // Fields allowed in the StorefrontLinkAddPayload (Go backend)
                 storeType,
-                storeName: storeName || `${storeType} Link`, // Default name if empty
-                apiKey, // Send credentials only when adding
-                apiSecret, // Send credentials only when adding
+                storeName: storeName || `${storeType} Link`,
+                apiKey,
+                apiSecret,
                 storeId,
                 storeUrl,
-                // Do not send 'id' when adding
             };
         }
 
-        // --- Make API Call ---
         try {
             const response = await fetch(apiUrl, {
                 method: apiMethod,
-                headers: {
-                    'Content-Type': 'application/json',
-                    // Include auth headers if your API requires them
-                    // 'Authorization': `Bearer ${token}`
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
             });
 
             if (!response.ok) {
-                // Try to get error message from backend response body
-                 const errorText = await response.text();
-                 // Use backend error text if available, otherwise provide a generic message
-                 throw new Error(errorText || `Failed to ${isEditing ? 'update' : 'add'} storefront. Status: ${response.status}`);
+                const errorText = await response.text();
+                throw new Error(errorText || `Failed to ${isEditing ? 'update' : 'add'} storefront. Status: ${response.status}`);
             }
-
-            // Success! Call the callback passed from parent
-            onSubmitSuccess();
+            onSubmitSuccess(); // Close modal and trigger refresh via parent
 
         } catch (err) {
             console.error("Form submission error:", err);
-             // Display the error message (could be from backend or generic)
             setError(err.message || 'An unexpected error occurred.');
         } finally {
             setIsLoading(false);
         }
     };
 
-    // --- Render Modal Form ---
+    // --- ADDED: Delete Handler ---
+    const handleDelete = async () => {
+        // Double-check we are in edit mode and have an ID
+        if (!isEditing || !storefront || !storefront.id) {
+            setError("Cannot delete - storefront data missing.");
+            return;
+        }
+
+        // Confirmation dialog
+        const confirmDelete = window.confirm(
+            `Are you sure you want to unlink the storefront "${storefront.storeName || storefront.storeType}"? This action cannot be undone.`
+        );
+
+        if (!confirmDelete) {
+            return; // User cancelled
+        }
+
+        setIsLoading(true);
+        setError('');
+
+        try {
+            const apiUrl = `/api/delete_storefront?id=${storefront.id}`;
+            const response = await fetch(apiUrl, {
+                method: 'DELETE',
+                headers: {
+                    // Include auth headers if needed
+                    // 'Authorization': `Bearer ${token}`
+                },
+            });
+
+            if (!response.ok) {
+                 const errorText = await response.text();
+                 throw new Error(errorText || `Failed to delete storefront. Status: ${response.status}`);
+            }
+
+            // Success! Call the same success handler as add/update
+            // This will close the modal and trigger the refresh in Storefronts.js
+            onSubmitSuccess();
+
+        } catch (err) {
+             console.error("Delete error:", err);
+             setError(err.message || 'An unexpected error occurred during deletion.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+    // --- End Delete Handler ---
+
     return (
         <div className="modal-backdrop">
             <div className="modal-content storefront-form">
                 <h2>{formTitle}</h2>
-                <button className="modal-close-button" onClick={onClose} aria-label="Close">X</button> {/* Added aria-label */}
+                <button className="modal-close-button" onClick={onClose} aria-label="Close">X</button>
 
                 <form onSubmit={handleSubmit}>
-                    {/* Display error message if present */}
                     {error && <p className="form-error">{error}</p>}
 
+                    {/* --- Form Groups remain the same --- */}
                     {/* Store Type Dropdown - Disabled when editing */}
                     <div className="form-group">
                         <label htmlFor="storeType">Storefront Type *</label>
-                        <select
-                            id="storeType"
-                            value={storeType}
-                            onChange={(e) => setStoreType(e.target.value)}
-                            required
-                            disabled={isEditing} // Can't change type after creation
-                        >
-                            <option value="" disabled={storeType !== ''}>Select a type...</option> {/* Ensure placeholder is selectable if initial value is empty */}
-                            {SUPPORTED_STOREFRONTS.map(option => (
-                                <option key={option.value} value={option.value}>
-                                    {option.label}
-                                </option>
-                            ))}
+                        <select id="storeType" value={storeType} onChange={(e) => setStoreType(e.target.value)} required disabled={isEditing}>
+                            <option value="" disabled={storeType !== ''}>Select a type...</option>
+                            {SUPPORTED_STOREFRONTS.map(option => (<option key={option.value} value={option.value}>{option.label}</option>))}
                         </select>
                         {isEditing && <p className="form-note">Store type cannot be changed after linking.</p>}
                     </div>
-
                      {/* Store Name Input */}
                      <div className="form-group">
                         <label htmlFor="storeName">Link Name</label>
-                        <input
-                            type="text"
-                            id="storeName"
-                            value={storeName}
-                            onChange={(e) => setStoreName(e.target.value)}
-                            placeholder="e.g., My Primary Amazon Store"
-                        />
-                         <p className="form-note">Give your link a nickname (optional).</p>
+                        <input type="text" id="storeName" value={storeName} onChange={(e) => setStoreName(e.target.value)} placeholder="e.g., My Primary Amazon Store"/>
+                        <p className="form-note">Give your link a nickname (optional).</p>
                     </div>
-
-                    {/* --- Credentials Fields - ONLY visible when ADDING --- */}
+                    {/* Credentials Fields - ONLY visible when ADDING */}
                     {!isEditing && (
                          <>
                             <div className="form-group">
                                 <label htmlFor="apiKey">API Key *</label>
-                                <input
-                                    type="password" // Use password type
-                                    id="apiKey"
-                                    value={apiKey}
-                                    onChange={(e) => setApiKey(e.target.value)}
-                                    required
-                                    placeholder="Enter API Key from store"
-                                    autoComplete="new-password" // Prevent browser autofill issues sometimes
-                                />
+                                <input type="password" id="apiKey" value={apiKey} onChange={(e) => setApiKey(e.target.value)} required placeholder="Enter API Key from store" autoComplete="new-password"/>
                             </div>
                              <div className="form-group">
                                 <label htmlFor="apiSecret">API Secret / Token *</label>
-                                <input
-                                    type="password" // Use password type
-                                    id="apiSecret"
-                                    value={apiSecret}
-                                    onChange={(e) => setApiSecret(e.target.value)}
-                                    required
-                                    placeholder="Enter API Secret or Token"
-                                    autoComplete="new-password" // Prevent browser autofill issues sometimes
-                                />
-                                 <p className="form-note">Credentials are required for linking and are stored securely. They cannot be updated later; re-link if they change.</p>
+                                <input type="password" id="apiSecret" value={apiSecret} onChange={(e) => setApiSecret(e.target.value)} required placeholder="Enter API Secret or Token" autoComplete="new-password"/>
+                                <p className="form-note">Credentials are required for linking and are stored securely. They cannot be updated later; re-link if they change.</p>
                              </div>
                          </>
                     )}
-
                      {/* Store ID Input */}
                     <div className="form-group">
                         <label htmlFor="storeId">Store ID / Seller ID</label>
-                        <input
-                            type="text"
-                            id="storeId"
-                            value={storeId}
-                            onChange={(e) => setStoreId(e.target.value)}
-                            placeholder="Platform-specific ID (e.g., Amazon Seller ID)"
-                        />
+                        <input type="text" id="storeId" value={storeId} onChange={(e) => setStoreId(e.target.value)} placeholder="Platform-specific ID (e.g., Amazon Seller ID)"/>
                     </div>
-
                     {/* Store URL Input */}
                      <div className="form-group">
                         <label htmlFor="storeUrl">Store URL</label>
-                        <input
-                            type="url"
-                            id="storeUrl"
-                            value={storeUrl}
-                            onChange={(e) => setStoreUrl(e.target.value)}
-                            placeholder="e.g., https://www.amazon.com/yourstore (optional)"
-                        />
+                        <input type="url" id="storeUrl" value={storeUrl} onChange={(e) => setStoreUrl(e.target.value)} placeholder="e.g., https://www.amazon.com/yourstore (optional)"/>
                      </div>
+                    {/* --- End Form Groups --- */}
 
-
-                    {/* Form Actions */}
+                    {/* --- MODIFIED: Form Actions --- */}
                     <div className="form-actions">
+                         {/* ADDED: Delete button, only shown when editing */}
+                         {isEditing && (
+                            <button
+                                type="button"
+                                className="delete-button" // Add class for styling
+                                onClick={handleDelete}
+                                disabled={isLoading} // Disable while any action is loading
+                            >
+                                {isLoading ? 'Deleting...' : 'Delete Link'}
+                            </button>
+                        )}
+                        {/* Existing Cancel and Submit/Update buttons */}
                         <button type="button" onClick={onClose} disabled={isLoading}>Cancel</button>
                         <button type="submit" disabled={isLoading}>
-                            {/* Dynamic button text */}
                             {isLoading ? 'Saving...' : (isEditing ? 'Update Link' : 'Link Storefront')}
                         </button>
                     </div>
+                    {/* --- End Form Actions --- */}
                 </form>
             </div>
         </div>

--- a/front-runner/src/components/Storefronts.css
+++ b/front-runner/src/components/Storefronts.css
@@ -1,0 +1,77 @@
+/* Similar structure to Products.css */
+.my-storefronts {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: row;
+    background-color: #0b0b0b;
+    height: 100vh;
+}
+
+.my-storefronts-content {
+    /* Styles for the content area below the navbar */
+    padding: 20px;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.storefronts-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    border-bottom: 1px solid #ccc; /* Example */
+    padding-bottom: 10px;
+}
+
+.storefronts-header h1 {
+    margin: 0;
+}
+
+.add-new-button { /* Assuming same class as Products page */
+    /* Styles for your add button */
+     cursor: pointer;
+}
+
+.add-new-icon { /* Assuming same class as Products page */
+    width: 30px; /* Adjust size */
+    height: 30px; /* Adjust size */
+}
+
+
+.storefronts-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); /* Responsive grid */
+    gap: 20px;
+    position: relative; /* Needed for absolute positioning of the empty message */
+    min-height: 300px; /* Ensure container has height for the centered message */
+}
+
+.storefront-tile {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 15px;
+    background-color: #f9f9f9; /* Example background */
+    cursor: pointer;
+    transition: box-shadow 0.3s ease;
+    display: flex; /* Example layout */
+    flex-direction: column;
+    justify-content: space-between; /* Example layout */
+}
+
+.storefront-tile:hover {
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.storefront-info h2 {
+    margin-top: 0;
+    margin-bottom: 5px;
+    font-size: 1.2em;
+}
+
+.storefront-info p {
+    margin: 0;
+    font-size: 0.9em;
+    color: #555;
+}
+
+/* Add styles for placeholder text if needed */

--- a/front-runner/src/components/Storefronts.css
+++ b/front-runner/src/components/Storefronts.css
@@ -40,38 +40,89 @@
 
 .storefronts-container {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); /* Responsive grid */
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); /* Responsive grid */
     gap: 20px;
     position: relative; /* Needed for absolute positioning of the empty message */
     min-height: 300px; /* Ensure container has height for the centered message */
+}
+
+.storefronts-container > p {
+    width: 90%;
+    position: absolute;
+    text-align: center;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-style: italic;
+    color: gray;
 }
 
 .storefront-tile {
     border: 1px solid #ddd;
     border-radius: 8px;
     padding: 15px;
-    background-color: #f9f9f9; /* Example background */
+    background-color: #181818; /* Example background */
     cursor: pointer;
-    transition: box-shadow 0.3s ease;
-    display: flex; /* Example layout */
-    flex-direction: column;
-    justify-content: space-between; /* Example layout */
+    transition: box-shadow 0.3s ease, border-color 0.3s ease;
+    padding: 15px;
+    display: flex; /* Use flexbox for layout */
+    align-items: center; /* Vertically align items */
+    gap: 15px; /* Space between favicon and info */
+    color: white; /* Ensure text is white */
+    min-height: 80px; /* Ensure a minimum height */
 }
 
 .storefront-tile:hover {
-    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    border-color: #aaa; /* Example hover border */
+}
+
+.storefront-info {
+    display: flex;
+    flex-direction: column;
+    /* Allow text info to take remaining space */
+    flex-grow: 1;
+    /* Prevent overflow issues */
+    min-width: 0; /* Important for text ellipsis in flex children */
 }
 
 .storefront-info h2 {
-    margin-top: 0;
-    margin-bottom: 5px;
-    font-size: 1.2em;
+    margin: 0 0 4px 0; /* Adjust spacing */
+    font-size: 1.1em; /* Adjust size */
+    white-space: nowrap; /* Prevent wrapping */
+    overflow: hidden;
+    text-overflow: ellipsis; /* Add ellipsis if name is too long */
 }
 
 .storefront-info p {
     margin: 0;
     font-size: 0.9em;
-    color: #555;
+    color: #aaa; /* Lighter color for subtitle */
+    white-space: nowrap; /* Prevent wrapping */
+    overflow: hidden;
+    text-overflow: ellipsis; /* Add ellipsis if type is too long */
 }
 
-/* Add styles for placeholder text if needed */
+/* Styling for the added favicon image */
+.storefront-favicon {
+    width: 32px;       /* Match the size requested (sz=32) */
+    height: 32px;
+    object-fit: contain; /* Scale image nicely */
+    flex-shrink: 0;    /* Prevent image from shrinking */
+    background-color: rgba(255, 255, 255, 0.1); /* Subtle bg for contrast / if image fails */
+    border-radius: 4px; /* Slightly rounded corners */
+}
+
+/* Optional: Styling for a subtle visit link */
+.storefront-link {
+    font-size: 0.8em;
+    color: #ff8c00; /* Example link color */
+    text-decoration: none;
+    margin-top: 5px;
+    display: inline-block; /* Needed for margin */
+}
+.storefront-link:hover {
+    text-decoration: underline;
+}
+
+/* Placeholder adjustments if needed */

--- a/front-runner/src/components/Storefronts.js
+++ b/front-runner/src/components/Storefronts.js
@@ -1,10 +1,143 @@
+// import NavBar from './NavBar';
+
+// const Storefronts = () => {
+//     return <div>
+//         <NavBar />
+//         <p style={{position: "absolute", top: "50%", right: "50%", color: "white"}}>not implemented yet</p>
+//     </div>;
+// }
+
+// export default Storefronts;
+import React, { useState, useEffect } from 'react';
+import './Storefronts.css'; // We'll need to create this CSS file
 import NavBar from './NavBar';
+import StorefrontLinkForm from './StorefrontLinkForm'; // We'll create this form component next
 
 const Storefronts = () => {
-    return <div>
-        <NavBar />
-        <p style={{position: "absolute", top: "50%", right: "50%", color: "white"}}>not implemented yet</p>
-    </div>;
-}
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [storefronts, setStorefronts] = useState([]);
+    // 'selectedStorefront' can be used if you later want to edit existing links
+    const [selectedStorefront, setSelectedStorefront] = useState(null);
+
+    // --- Fetch Storefronts ---
+    useEffect(() => {
+        const fetchStorefronts = async () => {
+            try {
+                // TODO: Update API endpoint when backend is ready
+                const response = await fetch('/api/get_storefronts');
+                if (!response.ok) {
+                    // Handle non-successful responses (e.g., 401 Unauthorized)
+                    if (response.status === 401) {
+                        console.error("User not authenticated.");
+                        // Optionally redirect to login or show a message
+                        setStorefronts([]); // Clear storefronts if unauthorized
+                        return;
+                    }
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                const data = await response.json();
+                setStorefronts(data || []); // Ensure data is an array, even if response is empty/null
+            } catch (error) {
+                console.error("Error fetching storefronts:", error);
+                setStorefronts([]); // Set to empty array on error
+            }
+        };
+        fetchStorefronts();
+    }, [isModalOpen]); // Re-fetch when the modal closes (in case a new one was added)
+
+    // --- Handlers ---
+    const handleAddNewClick = () => {
+        setSelectedStorefront(null); // Ensure we are adding, not editing
+        setIsModalOpen(true);
+    };
+
+    // Placeholder for future 'edit' functionality
+    const handleStorefrontClick = (storefront) => {
+        console.log("Clicked storefront:", storefront);
+        // If you implement editing:
+        // setSelectedStorefront(storefront);
+        // setIsModalOpen(true);
+        // For now, clicking a tile might not do anything, or could link out (TBD)
+    };
+
+    // Function to be passed to the modal to refresh data after adding/editing
+    const handleFormSubmitSuccess = () => {
+        setIsModalOpen(false);
+        // Optionally trigger a re-fetch immediately, though the useEffect dependency does this
+        // fetchStorefronts(); // uncomment if needed, but useEffect covers it
+    };
+
+
+    // --- Render ---
+    return (
+        <div className='my-storefronts'> {/* Use specific class */}
+            <NavBar />
+            <div className='my-storefronts-content'>
+                <div className='storefronts-header'> {/* Use specific class */}
+                    <h1>My Storefronts</h1>
+                    <div onClick={handleAddNewClick} className="add-new-button" style={{ cursor: 'pointer' }}>
+                        {/* Assuming you have a similar 'Add new' icon */}
+                        <img src={'../assets/Add new.svg'} alt='add new storefront' className='add-new-icon'/>
+                    </div>
+                </div>
+
+                <div className='storefronts-container'> {/* Use specific class */}
+                    {storefronts.length === 0 ? (
+                         <p style={{ /* Same styles as Products page */
+                            width: '90%',
+                            position: 'absolute',
+                            textAlign: 'center',
+                            top: '50%',
+                            left: '50%',
+                            transform: 'translate(-50%, -50%)',
+                            fontStyle: 'italic',
+                            color: 'gray' // Adjust color for your theme if needed
+                        }}>
+                            No storefronts linked yet. <a href="#" onClick={(e) => { e.preventDefault(); handleAddNewClick(); }} style={{ /* Same styles as Products page */
+                                textDecoration: 'underline',
+                                background: 'linear-gradient(to right, #FF4949, #FF8000)', // Example gradient
+                                backgroundClip: 'text',
+                                WebkitBackgroundClip: 'text',
+                                WebkitTextFillColor: 'transparent',
+                                borderBottom: '1px solid #FF4949' // Example border
+                            }}>Link a storefront to get started</a>
+                        </p>
+                    ) : (
+                        storefronts.map((storefront) => (
+                            // --- Storefront Tile ---
+                            // Adjust structure based on what data you get from the backend
+                            // For now, just showing the type and name
+                            <div
+                                key={storefront.id} // Assuming backend provides a unique 'id'
+                                className='storefront-tile' // Use specific class
+                                onClick={() => handleStorefrontClick(storefront)} // Add click handler
+                                // Optional: Add background image/icon based on store type later
+                            >
+                                <div className='storefront-info'>
+                                    {/* Display relevant info. Adjust field names based on your Go struct */}
+                                    <h2>{storefront.storeName || storefront.storeType}</h2> {/* Show user-given name or fallback to type */}
+                                    <p>{storefront.storeType}</p> {/* Show the type (e.g., "Amazon", "Pinterest") */}
+                                    {/* Maybe add store ID or URL if available and desired */}
+                                    {/* <p>ID: {storefront.storeId}</p> */}
+                                </div>
+                                {/* You might want an icon representing the store */}
+                                {/* <img src={`path/to/icons/${storefront.storeType}.png`} alt={storefront.storeType} /> */}
+                            </div>
+                        ))
+                    )}
+                </div>
+
+                {isModalOpen && (
+                    <StorefrontLinkForm
+                        // Pass selectedStorefront for potential editing in the future
+                        storefront={selectedStorefront}
+                        onClose={() => setIsModalOpen(false)}
+                        onSubmitSuccess={handleFormSubmitSuccess} // Pass the success handler
+                    />
+                )}
+            </div>
+        </div>
+    );
+};
 
 export default Storefronts;

--- a/front-runner/src/components/Storefronts.js
+++ b/front-runner/src/components/Storefronts.js
@@ -53,11 +53,11 @@ const Storefronts = () => {
 
     // Placeholder for future 'edit' functionality
     const handleStorefrontClick = (storefront) => {
-        console.log("Clicked storefront:", storefront);
-        // If you implement editing:
-        // setSelectedStorefront(storefront);
-        // setIsModalOpen(true);
-        // For now, clicking a tile might not do anything, or could link out (TBD)
+        console.log("Editing storefront:", storefront);
+        // Set the selected storefront data to pass to the modal
+        setSelectedStorefront(storefront);
+        // Open the modal
+        setIsModalOpen(true);
     };
 
     // Function to be passed to the modal to refresh data after adding/editing

--- a/front-runner/src/components/Storefronts.js
+++ b/front-runner/src/components/Storefronts.js
@@ -1,138 +1,133 @@
-// import NavBar from './NavBar';
-
-// const Storefronts = () => {
-//     return <div>
-//         <NavBar />
-//         <p style={{position: "absolute", top: "50%", right: "50%", color: "white"}}>not implemented yet</p>
-//     </div>;
-// }
-
-// export default Storefronts;
 import React, { useState, useEffect } from 'react';
 import './Storefronts.css'; // We'll need to create this CSS file
 import NavBar from './NavBar';
-import StorefrontLinkForm from './StorefrontLinkForm'; // We'll create this form component next
+import StorefrontLinkForm from './StorefrontLinkForm';
 
 const Storefronts = () => {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [storefronts, setStorefronts] = useState([]);
-    // 'selectedStorefront' can be used if you later want to edit existing links
     const [selectedStorefront, setSelectedStorefront] = useState(null);
 
     // --- Fetch Storefronts ---
     useEffect(() => {
         const fetchStorefronts = async () => {
             try {
-                // TODO: Update API endpoint when backend is ready
                 const response = await fetch('/api/get_storefronts');
                 if (!response.ok) {
-                    // Handle non-successful responses (e.g., 401 Unauthorized)
                     if (response.status === 401) {
                         console.error("User not authenticated.");
-                        // Optionally redirect to login or show a message
-                        setStorefronts([]); // Clear storefronts if unauthorized
+                        setStorefronts([]);
                         return;
                     }
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
                 const data = await response.json();
-                setStorefronts(data || []); // Ensure data is an array, even if response is empty/null
+                setStorefronts(data || []);
             } catch (error) {
                 console.error("Error fetching storefronts:", error);
-                setStorefronts([]); // Set to empty array on error
+                setStorefronts([]);
             }
         };
         fetchStorefronts();
-    }, [isModalOpen]); // Re-fetch when the modal closes (in case a new one was added)
+    }, [isModalOpen]);
 
     // --- Handlers ---
     const handleAddNewClick = () => {
-        setSelectedStorefront(null); // Ensure we are adding, not editing
+        setSelectedStorefront(null);
         setIsModalOpen(true);
     };
 
-    // Placeholder for future 'edit' functionality
     const handleStorefrontClick = (storefront) => {
         console.log("Editing storefront:", storefront);
-        // Set the selected storefront data to pass to the modal
         setSelectedStorefront(storefront);
-        // Open the modal
         setIsModalOpen(true);
     };
 
-    // Function to be passed to the modal to refresh data after adding/editing
     const handleFormSubmitSuccess = () => {
         setIsModalOpen(false);
-        // Optionally trigger a re-fetch immediately, though the useEffect dependency does this
-        // fetchStorefronts(); // uncomment if needed, but useEffect covers it
     };
 
+    // --- Helper to get domain for favicon ---
+    const getDomain = (url) => {
+        if (!url) return null;
+        try {
+            // Prepend http:// if no protocol exists, otherwise URL parsing might fail
+            const fullUrl = url.startsWith('http://') || url.startsWith('https://') ? url : `http://${url}`;
+            return new URL(fullUrl).hostname;
+        } catch (error) {
+            console.error("Error parsing URL for domain:", url, error);
+            return null; // Return null if URL is invalid
+        }
+    };
 
     // --- Render ---
     return (
-        <div className='my-storefronts'> {/* Use specific class */}
+        <div className='my-storefronts'>
             <NavBar />
             <div className='my-storefronts-content'>
-                <div className='storefronts-header'> {/* Use specific class */}
+                <div className='storefronts-header'>
                     <h1>My Storefronts</h1>
                     <div onClick={handleAddNewClick} className="add-new-button" style={{ cursor: 'pointer' }}>
-                        {/* Assuming you have a similar 'Add new' icon */}
                         <img src={'../assets/Add new.svg'} alt='add new storefront' className='add-new-icon'/>
                     </div>
                 </div>
 
-                <div className='storefronts-container'> {/* Use specific class */}
+                <div className='storefronts-container'>
                     {storefronts.length === 0 ? (
-                         <p style={{ /* Same styles as Products page */
-                            width: '90%',
-                            position: 'absolute',
-                            textAlign: 'center',
-                            top: '50%',
-                            left: '50%',
-                            transform: 'translate(-50%, -50%)',
-                            fontStyle: 'italic',
-                            color: 'gray' // Adjust color for your theme if needed
-                        }}>
-                            No storefronts linked yet. <a href="#" onClick={(e) => { e.preventDefault(); handleAddNewClick(); }} style={{ /* Same styles as Products page */
-                                textDecoration: 'underline',
-                                background: 'linear-gradient(to right, #FF4949, #FF8000)', // Example gradient
-                                backgroundClip: 'text',
-                                WebkitBackgroundClip: 'text',
-                                WebkitTextFillColor: 'transparent',
-                                borderBottom: '1px solid #FF4949' // Example border
-                            }}>Link a storefront to get started</a>
+                         <p style={{ /* Placeholder styles */ }}>
+                            No storefronts linked yet. <a href="#" onClick={(e) => { e.preventDefault(); handleAddNewClick(); }} style={{ /* Link styles */ }}>Link a storefront to get started</a>
                         </p>
                     ) : (
-                        storefronts.map((storefront) => (
-                            // --- Storefront Tile ---
-                            // Adjust structure based on what data you get from the backend
-                            // For now, just showing the type and name
-                            <div
-                                key={storefront.id} // Assuming backend provides a unique 'id'
-                                className='storefront-tile' // Use specific class
-                                onClick={() => handleStorefrontClick(storefront)} // Add click handler
-                                // Optional: Add background image/icon based on store type later
-                            >
-                                <div className='storefront-info'>
-                                    {/* Display relevant info. Adjust field names based on your Go struct */}
-                                    <h2>{storefront.storeName || storefront.storeType}</h2> {/* Show user-given name or fallback to type */}
-                                    <p>{storefront.storeType}</p> {/* Show the type (e.g., "Amazon", "Pinterest") */}
-                                    {/* Maybe add store ID or URL if available and desired */}
-                                    {/* <p>ID: {storefront.storeId}</p> */}
+                        storefronts.map((storefront) => {
+                            // Get domain for favicon service
+                            // Use storeUrl field which should contain the full URL
+                            const domain = getDomain(storefront.storeUrl);
+                            // Construct favicon URL using Google's service (adjust size with sz=)
+                            // Using domain_url is often more reliable than just domain=
+                            const faviconUrl = domain
+                                ? `https://www.google.com/s2/favicons?sz=32&domain_url=${encodeURIComponent(storefront.storeUrl)}`
+                                : null; // Fallback if URL is invalid or missing
+
+                            return (
+                                <div
+                                    key={storefront.id}
+                                    className='storefront-tile' // Apply styles for layout
+                                    onClick={() => handleStorefrontClick(storefront)}
+                                    style={{ cursor: 'pointer' }}
+                                >
+                                    {/* --- ADDED: Favicon Image --- */}
+                                    {faviconUrl && (
+                                        <img
+                                            src={faviconUrl}
+                                            alt={`${storefront.storeName || storefront.storeType} favicon`}
+                                            className="storefront-favicon" // Class for styling
+                                            // Add error handling for broken images
+                                            onError={(e) => {
+                                                e.target.style.display = 'none'; // Hide if favicon fails to load
+                                                // Optionally show a default icon/placeholder
+                                            }}
+                                        />
+                                    )}
+                                    {/* --- End Favicon Image --- */}
+
+                                    <div className='storefront-info'>
+                                        <h2>{storefront.storeName || storefront.storeType}</h2>
+                                        <p>{storefront.storeType}</p>
+                                        {/* Optionally display URL if desired */}
+                                        {/* {storefront.storeUrl && <a href={storefront.storeUrl.startsWith('http') ? storefront.storeUrl : `http://${storefront.storeUrl}`} target="_blank" rel="noopener noreferrer" className="storefront-link" onClick={(e) => e.stopPropagation()}>Visit Store</a>} */}
+                                    </div>
                                 </div>
-                                {/* You might want an icon representing the store */}
-                                {/* <img src={`path/to/icons/${storefront.storeType}.png`} alt={storefront.storeType} /> */}
-                            </div>
-                        ))
+                            );
+                        })
                     )}
                 </div>
 
+                {/* Modal Rendering */}
                 {isModalOpen && (
                     <StorefrontLinkForm
-                        // Pass selectedStorefront for potential editing in the future
                         storefront={selectedStorefront}
                         onClose={() => setIsModalOpen(false)}
-                        onSubmitSuccess={handleFormSubmitSuccess} // Pass the success handler
+                        onSubmitSuccess={handleFormSubmitSuccess}
                     />
                 )}
             </div>

--- a/front-runner_backend/.gitignore
+++ b/front-runner_backend/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.crt
 *.key
 .env
+.storefrontkey

--- a/front-runner_backend/README.md
+++ b/front-runner_backend/README.md
@@ -8,29 +8,34 @@ To create the database first you must get access to the postgresql shell:
 psql -U johnny -d postgres
 ```
 
-Replace `johnny` with the host system user (also need to change in the `.go` files).
+Replace `johnny` with the host system user (make sure to update in the `.env` file).
 
 Once in the shell run the following commands:
 
 ```
 CREATE DATABASE frontrunner;
 
-\c frontrunner
-
-CREATE TABLE users (
-    id SERIAL PRIMARY KEY,
-    email VARCHAR(50) UNIQUE NOT NULL,
-    password_hash VARCHAR(100) NOT NULL,
-    business_name VARCHAR(100)
-);
-
-CREATE TABLE product_images (
-    filename VARCHAR(50) PRIMARY KEY,
-    id int NOT NULL,
-    FOREIGN KEY (id) REFERENCES users(id)
-);
-
 quit
+```
+
+gorm will create all the necessary tables for you.
+
+## Build the Static Web Page
+
+```bash
+cd front-runner/
+
+npm run build
+
+cd ..
+```
+
+## Generate the Server Cert and the Storefront Encryption Key
+
+```bash
+cd front-runner_backend
+
+bash ./generateCert.sh
 ```
 
 ## Start GO Server
@@ -38,8 +43,12 @@ quit
 Start the go server by running:
 
 ```golang
-go run front-runner_backend/main.go
+go run .
 ```
+
+## To Access Page
+
+go to this webpage: https://localhost:8080/
 
 ## To Generate docs
 

--- a/front-runner_backend/docs/swagger.json
+++ b/front-runner_backend/docs/swagger.json
@@ -100,6 +100,69 @@
                 }
             }
         },
+        "/api/add_storefront": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Links a new external storefront (e.g., Amazon, Pinterest) to the user's account, storing credentials securely. Requires authentication.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "storefronts"
+                ],
+                "summary": "Link a new storefront",
+                "parameters": [
+                    {
+                        "description": "Storefront Link Details (including credentials like apiKey, apiSecret)",
+                        "name": "storefrontLink",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/storefronttable.StorefrontLinkAddPayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Successfully linked storefront (credentials omitted)",
+                        "schema": {
+                            "$ref": "#/definitions/storefronttable.StorefrontLinkReturn"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid input, missing fields, or JSON parsing error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - User session invalid or expired",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict - A link with this name/type already exists for the user",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - E.g., failed to encrypt, database error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/api/delete_product": {
             "delete": {
                 "description": "Deletes an existing product and its associated image if the product belongs to the authenticated user.",
@@ -134,6 +197,78 @@
                     },
                     "404": {
                         "description": "Product not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/delete_storefront": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Removes the link to an external storefront specified by its unique ID. User must own the link. Requires authentication.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "storefronts"
+                ],
+                "summary": "Unlink a storefront",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "format": "uint",
+                        "example": 123,
+                        "description": "ID of the Storefront Link to delete",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Storefront unlinked successfully",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "204": {
+                        "description": "Storefront unlinked successfully (No Content)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid or missing 'id' query parameter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - User session invalid or expired",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - User does not own this storefront link",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - Storefront link with the specified ID not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - Database deletion failed",
                         "schema": {
                             "type": "string"
                         }
@@ -255,6 +390,46 @@
                     },
                     "401": {
                         "description": "User not authenticated or unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/get_storefronts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all external storefronts linked by the currently authenticated user. Credentials are *never* included. Requires authentication.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "storefronts"
+                ],
+                "summary": "Get linked storefronts",
+                "responses": {
+                    "200": {
+                        "description": "List of linked storefronts (empty array if none)",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/storefronttable.StorefrontLinkReturn"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - User session invalid or expired",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - Database query failed",
                         "schema": {
                             "type": "string"
                         }
@@ -449,6 +624,158 @@
                             "type": "string"
                         }
                     }
+                }
+            }
+        },
+        "/api/update_storefront": {
+            "put": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Updates the name, store ID, or store URL of an existing storefront link belonging to the authenticated user. Store type and credentials cannot be updated via this endpoint.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "storefronts"
+                ],
+                "summary": "Update a storefront link",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "format": "uint",
+                        "example": 123,
+                        "description": "ID of the Storefront Link to update",
+                        "name": "id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update (storeName, storeId, storeUrl)",
+                        "name": "storefrontUpdate",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/storefronttable.StorefrontLinkUpdatePayload"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated storefront link details",
+                        "schema": {
+                            "$ref": "#/definitions/storefronttable.StorefrontLinkReturn"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - Invalid input, missing ID, or JSON parsing error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - User session invalid or expired",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - User does not own this storefront link",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found - Storefront link with the specified ID not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict - Update would violate a unique constraint (e.g., duplicate name)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error - Database update failed",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "storefronttable.StorefrontLinkAddPayload": {
+            "type": "object",
+            "properties": {
+                "apiKey": {
+                    "description": "Example credential field",
+                    "type": "string"
+                },
+                "apiSecret": {
+                    "description": "Example credential field",
+                    "type": "string"
+                },
+                "storeId": {
+                    "description": "Platform-specific ID",
+                    "type": "string"
+                },
+                "storeName": {
+                    "description": "User-defined nickname",
+                    "type": "string"
+                },
+                "storeType": {
+                    "type": "string"
+                },
+                "storeUrl": {
+                    "description": "Storefront URL",
+                    "type": "string"
+                }
+            }
+        },
+        "storefronttable.StorefrontLinkReturn": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "storeId": {
+                    "description": "Match frontend JSON keys",
+                    "type": "string"
+                },
+                "storeName": {
+                    "type": "string"
+                },
+                "storeType": {
+                    "type": "string"
+                },
+                "storeUrl": {
+                    "type": "string"
+                }
+            }
+        },
+        "storefronttable.StorefrontLinkUpdatePayload": {
+            "type": "object",
+            "properties": {
+                "storeId": {
+                    "description": "Platform-specific ID",
+                    "type": "string"
+                },
+                "storeName": {
+                    "description": "User-defined nickname",
+                    "type": "string"
+                },
+                "storeUrl": {
+                    "description": "Storefront URL",
+                    "type": "string"
                 }
             }
         }

--- a/front-runner_backend/docs/swagger.yaml
+++ b/front-runner_backend/docs/swagger.yaml
@@ -1,4 +1,51 @@
 basePath: /
+definitions:
+  storefronttable.StorefrontLinkAddPayload:
+    properties:
+      apiKey:
+        description: Example credential field
+        type: string
+      apiSecret:
+        description: Example credential field
+        type: string
+      storeId:
+        description: Platform-specific ID
+        type: string
+      storeName:
+        description: User-defined nickname
+        type: string
+      storeType:
+        type: string
+      storeUrl:
+        description: Storefront URL
+        type: string
+    type: object
+  storefronttable.StorefrontLinkReturn:
+    properties:
+      id:
+        type: integer
+      storeId:
+        description: Match frontend JSON keys
+        type: string
+      storeName:
+        type: string
+      storeType:
+        type: string
+      storeUrl:
+        type: string
+    type: object
+  storefronttable.StorefrontLinkUpdatePayload:
+    properties:
+      storeId:
+        description: Platform-specific ID
+        type: string
+      storeName:
+        description: User-defined nickname
+        type: string
+      storeUrl:
+        description: Storefront URL
+        type: string
+    type: object
 host: localhost:8080
 info:
   contact:
@@ -69,6 +116,49 @@ paths:
       summary: Add a new product
       tags:
       - product
+  /api/add_storefront:
+    post:
+      consumes:
+      - application/json
+      description: Links a new external storefront (e.g., Amazon, Pinterest) to the
+        user's account, storing credentials securely. Requires authentication.
+      parameters:
+      - description: Storefront Link Details (including credentials like apiKey, apiSecret)
+        in: body
+        name: storefrontLink
+        required: true
+        schema:
+          $ref: '#/definitions/storefronttable.StorefrontLinkAddPayload'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Successfully linked storefront (credentials omitted)
+          schema:
+            $ref: '#/definitions/storefronttable.StorefrontLinkReturn'
+        "400":
+          description: Bad Request - Invalid input, missing fields, or JSON parsing
+            error
+          schema:
+            type: string
+        "401":
+          description: Unauthorized - User session invalid or expired
+          schema:
+            type: string
+        "409":
+          description: Conflict - A link with this name/type already exists for the
+            user
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error - E.g., failed to encrypt, database error
+          schema:
+            type: string
+      security:
+      - ApiKeyAuth: []
+      summary: Link a new storefront
+      tags:
+      - storefronts
   /api/delete_product:
     delete:
       description: Deletes an existing product and its associated image if the product
@@ -97,6 +187,54 @@ paths:
       summary: Delete a product
       tags:
       - product
+  /api/delete_storefront:
+    delete:
+      description: Removes the link to an external storefront specified by its unique
+        ID. User must own the link. Requires authentication.
+      parameters:
+      - description: ID of the Storefront Link to delete
+        example: 123
+        format: uint
+        in: query
+        name: id
+        required: true
+        type: integer
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: Storefront unlinked successfully
+          schema:
+            type: string
+        "204":
+          description: Storefront unlinked successfully (No Content)
+          schema:
+            type: string
+        "400":
+          description: Bad Request - Invalid or missing 'id' query parameter
+          schema:
+            type: string
+        "401":
+          description: Unauthorized - User session invalid or expired
+          schema:
+            type: string
+        "403":
+          description: Forbidden - User does not own this storefront link
+          schema:
+            type: string
+        "404":
+          description: Not Found - Storefront link with the specified ID not found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error - Database deletion failed
+          schema:
+            type: string
+      security:
+      - ApiKeyAuth: []
+      summary: Unlink a storefront
+      tags:
+      - storefronts
   /api/get_product:
     get:
       description: Retreives an existing product and its associated metadata if the
@@ -180,6 +318,32 @@ paths:
       summary: Retrieves all product information for authenticated user.
       tags:
       - product
+  /api/get_storefronts:
+    get:
+      description: Retrieves a list of all external storefronts linked by the currently
+        authenticated user. Credentials are *never* included. Requires authentication.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of linked storefronts (empty array if none)
+          schema:
+            items:
+              $ref: '#/definitions/storefronttable.StorefrontLinkReturn'
+            type: array
+        "401":
+          description: Unauthorized - User session invalid or expired
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error - Database query failed
+          schema:
+            type: string
+      security:
+      - ApiKeyAuth: []
+      summary: Get linked storefronts
+      tags:
+      - storefronts
   /api/login:
     post:
       consumes:
@@ -308,4 +472,62 @@ paths:
       summary: Update a product
       tags:
       - product
+  /api/update_storefront:
+    put:
+      consumes:
+      - application/json
+      description: Updates the name, store ID, or store URL of an existing storefront
+        link belonging to the authenticated user. Store type and credentials cannot
+        be updated via this endpoint.
+      parameters:
+      - description: ID of the Storefront Link to update
+        example: 123
+        format: uint
+        in: query
+        name: id
+        required: true
+        type: integer
+      - description: Fields to update (storeName, storeId, storeUrl)
+        in: body
+        name: storefrontUpdate
+        required: true
+        schema:
+          $ref: '#/definitions/storefronttable.StorefrontLinkUpdatePayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully updated storefront link details
+          schema:
+            $ref: '#/definitions/storefronttable.StorefrontLinkReturn'
+        "400":
+          description: Bad Request - Invalid input, missing ID, or JSON parsing error
+          schema:
+            type: string
+        "401":
+          description: Unauthorized - User session invalid or expired
+          schema:
+            type: string
+        "403":
+          description: Forbidden - User does not own this storefront link
+          schema:
+            type: string
+        "404":
+          description: Not Found - Storefront link with the specified ID not found
+          schema:
+            type: string
+        "409":
+          description: Conflict - Update would violate a unique constraint (e.g.,
+            duplicate name)
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error - Database update failed
+          schema:
+            type: string
+      security:
+      - ApiKeyAuth: []
+      summary: Update a storefront link
+      tags:
+      - storefronts
 swagger: "2.0"

--- a/front-runner_backend/generateCert.sh
+++ b/front-runner_backend/generateCert.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -sha256 -days 3650 -nodes -subj "/C=US/ST=FL/L=Gainesville/O=FrontRunner/OU=/CN=localhost"
+
+openssl rand -base64 32 > .storefrontkey

--- a/front-runner_backend/go.mod
+++ b/front-runner_backend/go.mod
@@ -13,7 +13,15 @@ require (
 	gorm.io/gorm v1.25.12
 )
 
-require github.com/joho/godotenv v1.5.1
+require (
+	github.com/joho/godotenv v1.5.1
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect

--- a/front-runner_backend/internal/prodtable/prodtable.go
+++ b/front-runner_backend/internal/prodtable/prodtable.go
@@ -285,20 +285,37 @@ func UpdateProduct(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update all fields if provided
+	// if productName := r.FormValue("productName"); productName != "" {
+	// 	product.ProdName = productName
+	// }
+	// if productDescription := r.FormValue("product_description"); productDescription != "" {
+	// 	product.ProdDescription = productDescription
+	// }
+	// if productPrice, err := strconv.ParseFloat(r.FormValue("item_price"), 64); err == nil && productPrice > 0 {
+	// 	product.ProdPrice = productPrice
+	// }
+	// if productCount, err := strconv.Atoi(r.FormValue("stock_amount")); err == nil && productCount >= 0 {
+	// 	product.ProdCount = uint(productCount)
+	// }
+	// if productTags := r.FormValue("tags"); productTags != "" {
+	// 	product.ProdTags = productTags
+	// }
+
+	values := map[string]interface{}{}
 	if productName := r.FormValue("productName"); productName != "" {
-		product.ProdName = productName
+		values["ProdName"] = productName
 	}
 	if productDescription := r.FormValue("product_description"); productDescription != "" {
-		product.ProdDescription = productDescription
+		values["ProdDescription"] = productDescription
 	}
 	if productPrice, err := strconv.ParseFloat(r.FormValue("item_price"), 64); err == nil && productPrice > 0 {
-		product.ProdPrice = productPrice
+		values["ProdPrice"] = productPrice
 	}
 	if productCount, err := strconv.Atoi(r.FormValue("stock_amount")); err == nil && productCount >= 0 {
-		product.ProdCount = uint(productCount)
+		values["ProdCount"] = uint(productCount)
 	}
 	if productTags := r.FormValue("tags"); productTags != "" {
-		product.ProdTags = productTags
+		values["ProdTags"] = productTags
 	}
 
 	// Handle image update if provided
@@ -331,11 +348,13 @@ func UpdateProduct(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Update product's image ID
-		product.ImgID = image.ID
+		values["ImgID"] = image.ID
+		// product.ImgID = image.ID
 	}
 
 	// Save all updates
-	if err := db.Save(&product).Error; err != nil {
+	// if err := db.Save(&product).Error
+	if err := db.Model(&product).Updates(values).Error; err != nil {
 		http.Error(w, "Error updating product: "+err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/front-runner_backend/internal/prodtable/prodtable_test.go
+++ b/front-runner_backend/internal/prodtable/prodtable_test.go
@@ -338,16 +338,40 @@ func TestUpdateProduct(t *testing.T) {
 		t.Fatalf("failed to create product: %v", err)
 	}
 
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	writer.WriteField("product_description", "New description")
+	writer.WriteField("item_price", "15.50")
+	writer.WriteField("stock_amount", "5")
+
+	err = writer.Close()
+	if err != nil {
+		t.Fatalf("failed to create multipart form: %v", err)
+	}
+
 	// Prepare form data for updating the product.
-	form := url.Values{}
-	form.Set("product_description", "New description")
-	form.Set("item_price", "15.50")
-	form.Set("stock_amount", "5")
+	// form := url.Values{}
+	// form.Set("product_description", "New description")
+	// form.Set("item_price", "15.50")
+	// form.Set("stock_amount", "5")
+	// values := map[string]interface{}{
+	// 	"ProdDescription": "New description",
+	// 	"ProdPrice":       15.50,
+	// 	"ProdCount":       5,
+	// }
+
+	// if err := db.Model(&product).Updates(values).Error; err != nil {
+	// 	t.Fatalf("failed to update product: %v", err)
+	// }
 
 	// Using PUT method as indicated in the UpdateProduct Swagger annotation
-	req := httptest.NewRequest("PUT", "/api/update_product?id="+strconv.Itoa(int(product.ID)), strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req := httptest.NewRequest("PUT", "/api/update_product?id="+strconv.Itoa(int(product.ID)), body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.AddCookie(cookie)
+	// req := httptest.NewRequest("PUT", "/api/update_product?id="+strconv.Itoa(int(product.ID)), strings.NewReader(form.Encode()))
+	// req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// req.AddCookie(cookie)
 
 	rr := httptest.NewRecorder()
 

--- a/front-runner_backend/internal/routes/routes.go
+++ b/front-runner_backend/internal/routes/routes.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"front-runner/internal/login"
 	"front-runner/internal/prodtable"
+	"front-runner/internal/storefronttable"
 	"front-runner/internal/usertable"
 	"net/http"
 	"os"
@@ -88,6 +89,10 @@ func RegisterRoutes(router *mux.Router, logging bool) http.Handler {
 	api.HandleFunc("/get_product", prodtable.GetProduct).Methods("GET")
 	api.HandleFunc("/get_products", prodtable.GetProducts).Methods("GET")
 	api.HandleFunc("/get_product_image", prodtable.GetProductImage).Methods("GET")
+	// Storefront Table
+	api.HandleFunc("/add_storefront", storefronttable.AddStorefront).Methods("POST")
+	api.HandleFunc("/get_storefronts", storefronttable.GetStorefronts).Methods("GET")
+	api.HandleFunc("/delete_storefront", storefronttable.DeleteStorefront).Methods("DELETE")
 
 	api.PathPrefix("/").HandlerFunc(InvalidAPI)
 

--- a/front-runner_backend/internal/routes/routes.go
+++ b/front-runner_backend/internal/routes/routes.go
@@ -92,6 +92,7 @@ func RegisterRoutes(router *mux.Router, logging bool) http.Handler {
 	// Storefront Table
 	api.HandleFunc("/add_storefront", storefronttable.AddStorefront).Methods("POST")
 	api.HandleFunc("/get_storefronts", storefronttable.GetStorefronts).Methods("GET")
+	api.HandleFunc("/update_storefront", storefronttable.UpdateStorefront).Methods("PUT")
 	api.HandleFunc("/delete_storefront", storefronttable.DeleteStorefront).Methods("DELETE")
 
 	api.PathPrefix("/").HandlerFunc(InvalidAPI)

--- a/front-runner_backend/internal/storefronttable/encryption.go
+++ b/front-runner_backend/internal/storefronttable/encryption.go
@@ -1,0 +1,152 @@
+// front-runner/internal/storefronttable/encryption.go
+package storefronttable // Correct package name
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var encryptionKey []byte // Loaded during Setup
+
+const keyFileName = ".storefrontkey"
+
+// loadEncryptionKey retrieves the key from environment variables.
+// IMPORTANT: Ensure STOREFRONT_ENCRYPTION_KEY is set securely in your environment!
+// It should be a 32-byte base64 encoded string for AES-256.
+func loadEncryptionKey() error {
+	keyFilePath := filepath.Clean(keyFileName)
+
+	if _, err := os.Stat(keyFilePath); os.IsNotExist(err) {
+		// File doesn't exist - provide helpful error
+		log.Printf("Encryption key file '%s' not found.", keyFilePath)
+		log.Println("Please generate the key file by running the generateCert.sh script.")
+		log.Println("Ensure '.storefrontkey' is added to your .gitignore file.")
+		return fmt.Errorf("encryption key file not found at %s", keyFilePath)
+	} else if err != nil {
+		// Other error accessing the file (e.g., permissions)
+		return fmt.Errorf("error checking key file %s: %w", keyFilePath, err)
+	}
+
+	keyBase64Bytes, err := os.ReadFile(keyFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read encryption key file %s: %w", keyFilePath, err)
+	}
+
+	keyBase64 := strings.TrimSpace(string(keyBase64Bytes))
+
+	if keyBase64 == "" {
+		return fmt.Errorf("encryption key file %s is empty", keyFilePath)
+	}
+
+	key, err := base64.StdEncoding.DecodeString(keyBase64)
+	if err != nil {
+		return fmt.Errorf("failed to decode base64 key from file %s: %w", keyFilePath, err)
+	}
+
+	// Ensure key length is suitable for AES (16, 24, or 32 bytes)
+	// We'll enforce AES-256 (32 bytes) for strong security.
+	if len(key) != 32 {
+		return fmt.Errorf("decoded encryption key from %s must be 32 bytes for AES-256, got %d bytes", keyFilePath, len(key))
+	}
+	encryptionKey = key
+	log.Printf("Storefront encryption key loaded successfully from %s.", keyFilePath)
+	return nil
+}
+
+// encryptCredentials encrypts plaintext credentials using AES-GCM.
+// Returns a base64 encoded string containing nonce + ciphertext.
+func encryptCredentials(plaintext string) (string, error) {
+	if len(encryptionKey) == 0 {
+		// This should ideally not happen if Setup is called correctly
+		log.Println("Error: encryptCredentials called before encryption key was loaded.")
+		return "", errors.New("encryption key not available")
+	}
+
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		// Log internal error details
+		log.Printf("Error creating cipher block during encryption: %v", err)
+		return "", errors.New("internal error during encryption setup")
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		log.Printf("Error creating GCM during encryption: %v", err)
+		return "", errors.New("internal error during encryption setup")
+	}
+
+	// Allocate nonce space
+	nonce := make([]byte, gcm.NonceSize())
+	// Fill nonce with random data
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		log.Printf("Error generating nonce during encryption: %v", err)
+		return "", errors.New("internal error during encryption")
+	}
+
+	// Seal encrypts the plaintext and prepends the nonce to the ciphertext output.
+	// The nonce is passed in as the first argument, and also used for nonce generation internally.
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+
+	// Encode the result (nonce + ciphertext) to base64 for safe storage/transfer
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// decryptCredentials decrypts a base64 encoded ciphertext (nonce + encrypted data) using AES-GCM.
+func decryptCredentials(ciphertextBase64 string) (string, error) {
+	if len(encryptionKey) == 0 {
+		log.Println("Error: decryptCredentials called before encryption key was loaded.")
+		return "", errors.New("encryption key not available")
+	}
+
+	// Decode base64 string back to bytes
+	data, err := base64.StdEncoding.DecodeString(ciphertextBase64)
+	if err != nil {
+		// Log potentially invalid input format
+		log.Printf("Error decoding base64 ciphertext: %v", err)
+		return "", errors.New("invalid credentials format")
+	}
+
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		log.Printf("Error creating cipher block during decryption: %v", err)
+		return "", errors.New("internal error during decryption setup")
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		log.Printf("Error creating GCM during decryption: %v", err)
+		return "", errors.New("internal error during decryption setup")
+	}
+
+	nonceSize := gcm.NonceSize()
+	// Ensure received data is at least as long as the nonce
+	if len(data) < nonceSize {
+		log.Println("Error: Ciphertext received is shorter than nonce size.")
+		return "", errors.New("invalid credentials format")
+	}
+
+	// Extract nonce and actual ciphertext
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+
+	// Decrypt using gcm.Open
+	// The first argument (dst) is usually nil to let Open allocate memory.
+	// The nonce, ciphertext, and optional additional authenticated data (nil here) are provided.
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		// IMPORTANT: Decryption failure could be due to incorrect key OR tampered data.
+		// Do NOT reveal specific crypto errors to the client.
+		log.Printf("Failed to decrypt credentials (potential tampering or wrong key): %v", err)
+		return "", errors.New("failed to decrypt credentials") // Generic error is safer
+	}
+
+	return string(plaintext), nil
+}

--- a/front-runner_backend/internal/storefronttable/storefronttable.go
+++ b/front-runner_backend/internal/storefronttable/storefronttable.go
@@ -79,6 +79,7 @@ func Setup() {
 		}
 
 		// Get DB connection from coredbutils
+		coredbutils.LoadEnv()
 		db = coredbutils.GetDB()
 		if db == nil {
 			log.Fatal("FATAL: Database connection is nil in storefronttable Setup.")
@@ -102,6 +103,18 @@ func MigrateStorefrontDB() {
 		log.Fatalf("Storefront link migration failed: %v", err)
 	}
 	log.Println("Storefront link database migration complete.")
+}
+
+func ClearStorefrontTable(db *gorm.DB) error {
+	if db == nil {
+		return errors.New("storefront db is nil")
+	}
+	log.Println("DB COMMAND: DELETE FROM storefront_links")
+	if err := db.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&StorefrontLink{}).Error; err != nil {
+		return fmt.Errorf("error clearing storefront_links table: %w", err)
+	}
+	log.Println("Cleared storefront_links table successfully.")
+	return nil
 }
 
 // --- API Handlers ---

--- a/front-runner_backend/internal/storefronttable/storefronttable.go
+++ b/front-runner_backend/internal/storefronttable/storefronttable.go
@@ -1,0 +1,377 @@
+// front-runner/internal/storefronttable/storefronttable.go
+package storefronttable // Correct package name
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"front-runner/internal/coredbutils" // Use coredbutils for DB access
+	"front-runner/internal/login"       // Use login for auth
+	"log"
+	"net/http"
+	"strconv"
+	"strings" // Needed for unique constraint check example
+	"sync"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// --- Struct Definitions ---
+
+// StorefrontLink represents a linked external storefront in the database.
+type StorefrontLink struct {
+	ID          uint   `gorm:"primaryKey"`
+	UserID      uint   `gorm:"not null;index:idx_user_store_unique,unique,priority:1"` // Composite unique index
+	StoreType   string `gorm:"not null;index:idx_user_store_unique,unique,priority:2"` // Composite unique index
+	StoreName   string `gorm:"index:idx_user_store_unique,unique,priority:3"`          // Composite unique index
+	Credentials string `gorm:"not null;type:text"`                                     // Store encrypted data (use text type for potentially longer strings)
+	StoreID     string `gorm:"index"`                                                  // Index for potential lookups by StoreID
+	StoreURL    string
+	CreatedAt   time.Time `gorm:"autoCreateTime"`
+	UpdatedAt   time.Time `gorm:"autoUpdateTime"`
+}
+
+// StorefrontLinkAddPayload is used to decode the JSON body when adding a link.
+type StorefrontLinkAddPayload struct {
+	StoreType string `json:"storeType"`
+	StoreName string `json:"storeName"` // User-defined nickname
+	ApiKey    string `json:"apiKey"`    // Example credential field
+	ApiSecret string `json:"apiSecret"` // Example credential field
+	StoreId   string `json:"storeId"`   // Platform-specific ID
+	StoreUrl  string `json:"storeUrl"`  // Storefront URL
+	// Add other potential credential fields as needed per platform
+}
+
+// StorefrontLinkReturn is the struct returned to the frontend.
+// IMPORTANT: It omits the sensitive Credentials field.
+type StorefrontLinkReturn struct {
+	ID        uint   `json:"id"`
+	StoreType string `json:"storeType"`
+	StoreName string `json:"storeName"`
+	StoreID   string `json:"storeId"` // Match frontend JSON keys
+	StoreURL  string `json:"storeUrl"`
+}
+
+// --- Package Variables ---
+var (
+	db        *gorm.DB
+	setupOnce sync.Once
+)
+
+// --- Setup and Migration ---
+
+// Setup initializes the database connection for the storefronttable package
+// and ensures the encryption key is loaded.
+func Setup() {
+	setupOnce.Do(func() {
+		// Load encryption key first, fail early if not configured
+		// This refers to loadEncryptionKey in the same (storefronttable) package
+		if err := loadEncryptionKey(); err != nil {
+			// Use log.Fatalf to stop execution if security cannot be guaranteed
+			log.Fatalf("FATAL: Failed to setup storefronttable package security: %v", err)
+		}
+
+		// Get DB connection from coredbutils
+		db = coredbutils.GetDB()
+		if db == nil {
+			log.Fatal("FATAL: Database connection is nil in storefronttable Setup.")
+		}
+
+		log.Println("storefronttable package setup complete.")
+	})
+}
+
+// MigrateStorefrontDB runs the database migration for the StorefrontLink table.
+func MigrateStorefrontDB() {
+	// Ensure setup has run and db is initialized
+	if db == nil {
+		log.Fatal("Storefronttable Database connection is not initialized before migration. Ensure Setup() is called first.")
+	}
+	log.Println("Running storefront link database migrations...")
+	// AutoMigrate will create the table, add missing columns/indexes,
+	// but typically won't delete/change existing ones without extra configuration.
+	err := db.AutoMigrate(&StorefrontLink{})
+	if err != nil {
+		log.Fatalf("Storefront link migration failed: %v", err)
+	}
+	log.Println("Storefront link database migration complete.")
+}
+
+// --- API Handlers ---
+
+// AddStorefront handles linking a new external storefront.
+// @Summary      Link a new storefront
+// @Description  Links a new external storefront (e.g., Amazon, Pinterest) to the user's account, storing credentials securely. Requires authentication.
+// @Tags         storefronts
+// @Accept       json
+// @Produce      json
+// @Param        storefrontLink body StorefrontLinkAddPayload true "Storefront Link Details (including credentials like apiKey, apiSecret)"
+// @Success      201 {object} StorefrontLinkReturn "Successfully linked storefront (credentials omitted)"
+// @Failure      400 {string} string "Bad Request - Invalid input, missing fields, or JSON parsing error"
+// @Failure      401 {string} string "Unauthorized - User session invalid or expired"
+// @Failure      409 {string} string "Conflict - A link with this name/type already exists for the user"
+// @Failure      500 {string} string "Internal Server Error - E.g., failed to encrypt, database error"
+// @Security     ApiKeyAuth
+// @Router       /api/add_storefront [post]
+func AddStorefront(w http.ResponseWriter, r *http.Request) {
+	userID, ok := checkAuth(w, r) // Check authentication first
+	if !ok {
+		return // Error response already sent by checkAuth
+	}
+
+	var payload StorefrontLinkAddPayload
+	// Decode JSON body
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "Invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close() // Good practice to close body
+
+	// --- Basic Input Validation ---
+	if strings.TrimSpace(payload.StoreType) == "" {
+		http.Error(w, "Missing required field: storeType", http.StatusBadRequest)
+		return
+	}
+	// Example validation: Require credentials for certain types if known
+	if payload.StoreType == "amazon" && (payload.ApiKey == "" || payload.ApiSecret == "") {
+		http.Error(w, "apiKey and apiSecret are required for Amazon links", http.StatusBadRequest)
+		return
+	}
+	// Add more specific validation as needed per store type
+
+	// --- Prepare and Encrypt Credentials ---
+	// Structure credentials for consistent encryption (JSON map is flexible)
+	credentialsMap := map[string]string{
+		// Only include non-empty credentials provided by the user
+	}
+	if payload.ApiKey != "" {
+		credentialsMap["apiKey"] = payload.ApiKey
+	}
+	if payload.ApiSecret != "" {
+		credentialsMap["apiSecret"] = payload.ApiSecret
+	}
+	// Add other fields from payload if they are considered sensitive
+
+	// Only encrypt if there are actual credentials to store
+	var encryptedCredentials string
+	var err error
+	if len(credentialsMap) > 0 {
+		credentialsJSON, errMarshal := json.Marshal(credentialsMap)
+		if errMarshal != nil {
+			log.Printf("Error marshalling credentials for user %d: %v", userID, errMarshal)
+			http.Error(w, "Internal server error while preparing credentials", http.StatusInternalServerError)
+			return
+		}
+		encryptedCredentials, err = encryptCredentials(string(credentialsJSON))
+		if err != nil {
+			log.Printf("Error encrypting credentials for user %d: %v", userID, err)
+			http.Error(w, "Failed to secure credentials", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		// Handle cases where no credentials are provided, if allowed by your logic
+		// encryptedCredentials = "" // Or perhaps return an error if credentials are required
+		log.Printf("Warning: No credentials provided for storefront type %s for user %d", payload.StoreType, userID)
+		// Depending on requirements, you might allow linking without credentials
+		// For now, let's assume some credentials (even empty ones if allowed) lead to an empty encrypted string
+		encryptedCredentials = ""
+		// If you *require* credentials, add validation earlier.
+	}
+
+	// --- Create Database Record ---
+	newLink := StorefrontLink{
+		UserID:      userID,
+		StoreType:   payload.StoreType,
+		StoreName:   payload.StoreName,
+		Credentials: encryptedCredentials, // Store the encrypted string
+		StoreID:     payload.StoreId,
+		StoreURL:    payload.StoreUrl,
+	}
+
+	// Provide a default name if the user didn't specify one
+	if strings.TrimSpace(newLink.StoreName) == "" {
+		newLink.StoreName = fmt.Sprintf("%s Link", payload.StoreType) // e.g., "Amazon Link"
+	}
+
+	// Attempt to save to database
+	result := db.Create(&newLink)
+	if result.Error != nil {
+		// Check specifically for unique constraint violation
+		// Note: Error message checks are database-dependent and brittle.
+		// Using GORM's error types or specific DB driver errors is more reliable if available.
+		// Example check for PostgreSQL unique violation:
+		if strings.Contains(result.Error.Error(), "unique constraint") || strings.Contains(result.Error.Error(), "idx_user_store_unique") {
+			http.Error(w, "A storefront link with this type and name already exists for your account.", http.StatusConflict) // 409 Conflict
+		} else {
+			// Log the unexpected database error
+			log.Printf("Error saving storefront link for user %d: %v", userID, result.Error)
+			http.Error(w, "Failed to save storefront link due to a database error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// --- Return Success Response (Safe Data Only) ---
+	// Create the return object *without* credentials
+	returnData := StorefrontLinkReturn{
+		ID:        newLink.ID,
+		StoreType: newLink.StoreType,
+		StoreName: newLink.StoreName,
+		StoreID:   newLink.StoreID,
+		StoreURL:  newLink.StoreURL,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated) // 201 Created
+	json.NewEncoder(w).Encode(returnData)
+}
+
+// GetStorefronts retrieves all linked storefronts for the logged-in user.
+// @Summary      Get linked storefronts
+// @Description  Retrieves a list of all external storefronts linked by the currently authenticated user. Credentials are *never* included. Requires authentication.
+// @Tags         storefronts
+// @Produce      json
+// @Success      200 {array} StorefrontLinkReturn "List of linked storefronts (empty array if none)"
+// @Failure      401 {string} string "Unauthorized - User session invalid or expired"
+// @Failure      500 {string} string "Internal Server Error - Database query failed"
+// @Security     ApiKeyAuth
+// @Router       /api/get_storefronts [get]
+func GetStorefronts(w http.ResponseWriter, r *http.Request) {
+	userID, ok := checkAuth(w, r)
+	if !ok {
+		return
+	}
+
+	var links []StorefrontLink
+	// Query database for links belonging to the user, order them consistently
+	result := db.Where("user_id = ?", userID).Order("store_type asc, store_name asc").Find(&links)
+	if result.Error != nil {
+		log.Printf("Error retrieving storefront links for user %d: %v", userID, result.Error)
+		http.Error(w, "Failed to retrieve storefront links", http.StatusInternalServerError)
+		return
+	}
+
+	// Prepare return data (transforming DB model to safe return model)
+	returnData := make([]StorefrontLinkReturn, len(links)) // Pre-allocate slice
+	for i, link := range links {
+		returnData[i] = StorefrontLinkReturn{
+			ID:        link.ID,
+			StoreType: link.StoreType,
+			StoreName: link.StoreName,
+			StoreID:   link.StoreID,
+			StoreURL:  link.StoreURL,
+		}
+	}
+
+	// Return the array (it will be `[]` if no links were found, which is correct)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK) // 200 OK
+	json.NewEncoder(w).Encode(returnData)
+}
+
+// DeleteStorefront removes a linked storefront for the logged-in user by its ID.
+// @Summary      Unlink a storefront
+// @Description  Removes the link to an external storefront specified by its unique ID. User must own the link. Requires authentication.
+// @Tags         storefronts
+// @Produce      plain
+// @Param        id query integer true "ID of the Storefront Link to delete" Format(uint) example(123)
+// @Success      200 {string} string "Storefront unlinked successfully"
+// @Success      204 {string} string "Storefront unlinked successfully (No Content)"
+// @Failure      400 {string} string "Bad Request - Invalid or missing 'id' query parameter"
+// @Failure      401 {string} string "Unauthorized - User session invalid or expired"
+// @Failure      403 {string} string "Forbidden - User does not own this storefront link"
+// @Failure      404 {string} string "Not Found - Storefront link with the specified ID not found"
+// @Failure      500 {string} string "Internal Server Error - Database deletion failed"
+// @Security     ApiKeyAuth
+// @Router       /api/delete_storefront [delete]
+func DeleteStorefront(w http.ResponseWriter, r *http.Request) {
+	userID, ok := checkAuth(w, r)
+	if !ok {
+		return
+	}
+
+	// --- Get and Validate ID from Query Parameter ---
+	idStr := r.URL.Query().Get("id")
+	if idStr == "" {
+		http.Error(w, "Missing required query parameter: id", http.StatusBadRequest)
+		return
+	}
+
+	// Parse the ID string to an unsigned integer
+	linkID64, err := strconv.ParseUint(idStr, 10, 32) // Use 32 or 64 based on expected ID size
+	if err != nil {
+		http.Error(w, "Invalid ID format: must be a positive integer", http.StatusBadRequest)
+		return
+	}
+	linkID := uint(linkID64) // Convert to uint for GORM matching
+
+	// --- Find the Link in Database ---
+	var link StorefrontLink
+	// Use GORM's First method, which finds by primary key automatically if given an integer
+	result := db.First(&link, linkID)
+
+	// Handle errors during find
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			http.Error(w, fmt.Sprintf("Storefront link with ID %d not found", linkID), http.StatusNotFound) // 404 Not Found
+		} else {
+			// Log unexpected database error
+			log.Printf("Error finding storefront link ID %d for deletion: %v", linkID, result.Error)
+			http.Error(w, "Internal server error while searching for link", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// --- Verify Ownership ---
+	// Crucial security check: does the found link belong to the logged-in user?
+	if link.UserID != userID {
+		// Log potential security violation attempt
+		log.Printf("Security violation: User %d attempted to delete storefront link ID %d owned by user %d", userID, linkID, link.UserID)
+		http.Error(w, "Forbidden: You do not have permission to delete this storefront link", http.StatusForbidden) // 403 Forbidden
+		return
+	}
+
+	// --- Delete the Link ---
+	// Perform the delete operation using the found link object
+	deleteResult := db.Delete(&link)
+	if deleteResult.Error != nil {
+		// Log error during deletion
+		log.Printf("Error deleting storefront link ID %d for user %d: %v", linkID, userID, deleteResult.Error)
+		http.Error(w, "Failed to delete storefront link due to a database error", http.StatusInternalServerError)
+		return
+	}
+
+	// Check if any row was actually deleted (optional, but good practice)
+	if deleteResult.RowsAffected == 0 {
+		log.Printf("Warning: Delete command for storefront link ID %d affected 0 rows (was it already deleted?)", linkID)
+		// Still return success, as the desired state (link doesn't exist) is achieved
+	}
+
+	// --- Return Success Response ---
+	// Respond with 200 OK or 204 No Content (both indicate success)
+	w.WriteHeader(http.StatusOK) // 200 OK with optional message
+	fmt.Fprintf(w, "Storefront link (ID: %d) unlinked successfully", linkID)
+
+	// Alternatively, use 204 No Content if no message body is needed:
+	// w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Helper Functions ---
+
+// checkAuth is a helper to verify login status and retrieve UserID.
+// It writes appropriate HTTP errors (401, 500) directly to the response writer.
+// Returns the UserID and true if authenticated, otherwise 0 and false.
+func checkAuth(w http.ResponseWriter, r *http.Request) (userID uint, ok bool) {
+	if !login.IsLoggedIn(r) {
+		http.Error(w, "Unauthorized: Please log in.", http.StatusUnauthorized)
+		return 0, false
+	}
+	id, err := login.GetUserID(r)
+	if err != nil {
+		// Log the internal session error
+		log.Printf("Error retrieving UserID from session: %v", err)
+		http.Error(w, "Internal Server Error: Could not verify user session.", http.StatusInternalServerError)
+		return 0, false
+	}
+	return id, true
+}

--- a/front-runner_backend/internal/storefronttable/storefronttable_test.go
+++ b/front-runner_backend/internal/storefronttable/storefronttable_test.go
@@ -1,0 +1,440 @@
+// front-runner/internal/storefronttable/storefronttable_test.go
+package storefronttable
+
+import (
+	"bytes"
+	// "context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath" // <-- Import filepath again
+	"regexp"        // <-- Import regexp again
+	"strings"
+	"testing"
+	"time"
+
+	"front-runner/internal/login"
+	"front-runner/internal/usertable"
+
+	"github.com/joho/godotenv" // <-- Import godotenv again
+	asrt "github.com/stretchr/testify/assert"
+	req "github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+// --- Constants ---
+// Adjust this if your project root identifier is different
+// const projectDirName = "front-runner_backend" // Or "front-runner_backend"
+
+// --- Test Utility Functions ---
+// (registerAndLoginTestUser function remains the same)
+// ... registerAndLoginTestUser definition ...
+func registerAndLoginTestUser(t *testing.T, email, password, businessName string) (uint, *http.Cookie, error) {
+	// 1. Register User
+	regForm := url.Values{}
+	regForm.Add("email", email)
+	regForm.Add("password", password)
+	regForm.Add("business_name", businessName)
+
+	regReq := httptest.NewRequest(http.MethodPost, "/api/register", strings.NewReader(regForm.Encode()))
+	regReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	regRec := httptest.NewRecorder()
+
+	usertable.RegisterUser(regRec, regReq) // Call actual handler
+
+	if regRec.Code != http.StatusOK {
+		return 0, nil, fmt.Errorf("failed to register test user '%s', status %d, body: %s", email, regRec.Code, regRec.Body.String())
+	}
+	t.Logf("Successfully registered test user: %s", email)
+
+	// Retrieve UserID after registration (essential for linking storefronts)
+	var registeredUser usertable.User
+	// Use the main 'db' connection initialized in TestMain
+	err := db.Where("email = ?", email).First(&registeredUser).Error
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to retrieve registered user '%s' from DB: %w", email, err)
+	}
+	if registeredUser.ID == 0 {
+		return 0, nil, fmt.Errorf("retrieved user '%s' has ID 0", email)
+	}
+	userID := registeredUser.ID
+	t.Logf("Retrieved UserID %d for %s", userID, email)
+
+	// 2. Login User
+	loginForm := url.Values{}
+	loginForm.Add("email", email)
+	loginForm.Add("password", password) // Use the same password
+
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(loginForm.Encode()))
+	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginRec := httptest.NewRecorder()
+
+	login.LoginUser(loginRec, loginReq) // Call actual handler
+
+	// Login might redirect (303) or return OK (200) depending on implementation
+	if loginRec.Code != http.StatusSeeOther && loginRec.Code != http.StatusOK {
+		return 0, nil, fmt.Errorf("failed to log in test user '%s', expected 303 or 200, got status %d, body: %s", email, loginRec.Code, loginRec.Body.String())
+	}
+
+	// 3. Extract Session Cookie
+	cookies := loginRec.Result().Cookies()
+	var sessionCookie *http.Cookie
+	for _, c := range cookies {
+		// Adjust cookie name if different
+		if c.Name == "auth" {
+			sessionCookie = c
+			break
+		}
+	}
+
+	if sessionCookie == nil {
+		return 0, nil, fmt.Errorf("session cookie 'auth' not found after login for user '%s'", email)
+	}
+	t.Logf("Successfully logged in test user %s and obtained session cookie", email)
+
+	return userID, sessionCookie, nil
+}
+
+func makeTestUser(t *testing.T, password string) (uint, *http.Cookie, error) {
+	require := req.New(t)
+	uniqueEmail := fmt.Sprintf("addsf_%d@example.com", time.Now().UnixNano())
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("error hashing test password: %v", err)
+	}
+	userID, sessionCookie, err := registerAndLoginTestUser(t, uniqueEmail, string(hashedPassword), "Add SF Test Biz")
+	require.NoError(err, "Setup failed: Could not register and login test user")
+	require.NotNil(sessionCookie, "Setup failed: Session cookie is nil")
+	require.NotZero(userID, "Setup failed: UserID is zero")
+
+	return userID, sessionCookie, nil
+}
+
+// --- TestMain for Simplified Setup/Teardown (No Mocking Version) ---
+
+func TestMain(m *testing.M) {
+	log.Println("--- TestMain Start (No Mocking) ---")
+
+	// --- Load Environment Variables for Local Test Database --- // <-- ADD THIS SECTION BACK
+	// Find project root dynamically
+	re := regexp.MustCompile(`^(.*` + projectDirName + `)`)
+	cwd, _ := os.Getwd()
+	rootPath := re.FindString(cwd)
+	if rootPath == "" {
+		log.Printf("WARN: Could not find project root based on '%s'. Searching for .env in current dir: %s", projectDirName, cwd)
+		rootPath = cwd
+	}
+	envPath := filepath.Join(rootPath, ".env")
+	log.Printf("TEST: Attempting to load environment variables from: %s", envPath)
+	err := godotenv.Load(envPath)
+	if err != nil {
+		// Fail if .env is crucial and not found
+		log.Fatalf("FATAL: Failed to load .env file from %s: %v. DB variables (like DB_HOST) are required.", envPath, err)
+	} else {
+		log.Printf("TEST: Loaded environment variables from %s", envPath)
+	}
+	// Optional: Call coredbutils.LoadEnv() if it exists and reads from os.Getenv()
+	// coredbutils.LoadEnv()
+
+	// --- Run Package Setups ---
+	// Setups will now use the environment variables loaded from .env
+	log.Println("TEST: Calling package Setups...")
+	usertable.Setup()
+	login.Setup()
+	Setup() // Uses package-level 'db', loads real key file
+
+	// --- Verify DB Connection and Key Loading ---
+	if db == nil {
+		log.Fatal("FATAL: Database connection (db) is nil after Setup(). Check DB config in .env and DB service.")
+	}
+	if len(encryptionKey) == 0 {
+		log.Fatal("FATAL: Encryption key was not loaded after Setup(). Ensure '.storefrontkey' exists and is readable.")
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Fatalf("FATAL: Failed to get underlying SQL DB interface: %v", err)
+	}
+	if err = sqlDB.Ping(); err != nil {
+		log.Fatalf("FATAL: Failed to ping local database after Setup(): %v. Check connection details in .env.", err)
+	}
+	log.Println("TEST: Successfully connected to database and loaded encryption key.")
+
+	// --- Run Migrations ---
+	log.Println("TEST: Running database migrations...")
+	usertable.MigrateUserDB()
+	MigrateStorefrontDB()
+	log.Println("TEST: Database migrations complete.")
+
+	// --- Clear Tables Before Running Tests ---
+	log.Println("TEST: Clearing tables before running tests...")
+	// Use require inside TestMain - don't pass 't' (nil here)
+	if err := usertable.ClearUserTable(db); err != nil {
+		log.Fatalf("FATAL: Failed to clear users table before tests: %v", err)
+	}
+	if err := ClearStorefrontTable(db); err != nil {
+		log.Fatalf("FATAL: Failed to clear storefront table before tests: %v", err)
+	}
+
+	// --- Run Tests ---
+	log.Println("TEST: Starting test execution...")
+	exitCode := m.Run()
+	log.Println("TEST: Finished test execution.")
+
+	// --- Clear Tables After Tests ---
+	log.Println("TEST: Clearing tables after running tests...")
+	if err := usertable.ClearUserTable(db); err != nil {
+		log.Printf("ERROR: Failed to clear users table after tests: %v", err)
+	}
+	if err := ClearStorefrontTable(db); err != nil {
+		log.Printf("ERROR: Failed to clear storefront table after tests: %v", err)
+	}
+
+	log.Println("--- TestMain End (No Mocking) ---")
+	os.Exit(exitCode)
+}
+
+// --- Test Functions ---
+// (Test functions remain the same as the previous "No Mocking" version)
+// ... TestAddStorefront_RealLogin definition ...
+func TestAddStorefront_RealLogin(t *testing.T) {
+	// assert := asrt.New(t)
+	// require := req.New(t)
+	// TestMain clears tables
+
+	// --- Setup: Register and Login User ---
+	password := "testpassword123"
+	userID, sessionCookie, _ := makeTestUser(t, password)
+
+	// --- Test Case 1: Success ---
+	t.Run("Success", func(t *testing.T) {
+		assert := asrt.New(t) // Use subtest 't'
+		require := req.New(t) // Use subtest 't'
+
+		payload := StorefrontLinkAddPayload{
+			StoreType: "amazon_real_login",
+			StoreName: "My Amazon Store (Real Login)",
+			ApiKey:    "real_key_456",
+			ApiSecret: "real_secret_abc",
+			StoreId:   "real_store789",
+			StoreUrl:  "http://amazon.com/real_store789",
+		}
+		body, _ := json.Marshal(payload)
+
+		// Create request and ADD THE COOKIE
+		req := httptest.NewRequest(http.MethodPost, "/api/add_storefront", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(sessionCookie) // Add the obtained session cookie
+
+		rr := httptest.NewRecorder()
+		AddStorefront(rr, req) // Call the handler
+
+		assert.Equal(http.StatusCreated, rr.Code, "Expected status 201 Created")
+
+		// ... (rest of assertions for success case, verifying response and DB) ...
+		var responseData StorefrontLinkReturn
+		err := json.Unmarshal(rr.Body.Bytes(), &responseData)
+		require.NoError(err, "Failed to unmarshal response") // No 't' needed
+		assert.Equal(payload.StoreType, responseData.StoreType)
+		assert.Equal(payload.StoreName, responseData.StoreName)
+		assert.NotEmpty(responseData.ID)
+
+		// Verify in DB
+		var savedLink StorefrontLink
+		dbResult := db.First(&savedLink, responseData.ID)
+		require.NoError(dbResult.Error)        // No 't' needed
+		assert.Equal(userID, savedLink.UserID) // IMPORTANT: Check against the real UserID
+		assert.Equal(payload.StoreType, savedLink.StoreType)
+		// ... (verify credentials via decryption as before)
+		decryptedCreds, decryptErr := decryptCredentials(savedLink.Credentials)
+		require.NoError(decryptErr) // No 't' needed
+		expectedCredsMap := map[string]string{"apiKey": payload.ApiKey, "apiSecret": payload.ApiSecret}
+		expectedCredsJSON, _ := json.Marshal(expectedCredsMap)
+		assert.JSONEq(string(expectedCredsJSON), decryptedCreds)
+	})
+
+	// --- Test Case 2: Unauthorized (No Cookie) ---
+	t.Run("Unauthorized", func(t *testing.T) {
+		assert := asrt.New(t) // Use subtest 't'
+
+		payload := StorefrontLinkAddPayload{StoreType: "test_unauth_real"}
+		body, _ := json.Marshal(payload)
+
+		// Create request WITHOUT the cookie
+		req := httptest.NewRequest(http.MethodPost, "/api/add_storefront", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		// NO req.AddCookie(sessionCookie)
+
+		rr := httptest.NewRecorder()
+		AddStorefront(rr, req)
+
+		assert.Equal(http.StatusUnauthorized, rr.Code)
+		// You might want to check the specific error message from your checkAuth helper
+		assert.Contains(rr.Body.String(), "Unauthorized")
+	})
+}
+
+// ... TestGetUpdateDeleteFlow_RealLogin definition ...
+func TestGetUpdateDeleteFlow_RealLogin(t *testing.T) {
+	assert := asrt.New(t)
+	require := req.New(t)
+	// TestMain clears tables
+
+	// --- Setup: Register and Login User ---
+	// uniqueEmail := fmt.Sprintf("flow_%d@example.com", time.Now().UnixNano())
+	password := "flowpassword"
+	_, sessionCookie, err := makeTestUser(t, password)
+	// userID, sessionCookie, err := registerAndLoginTestUser(t, uniqueEmail, password, "Flow Test Biz")
+	// require.NoError(err, "Setup failed: Could not register and login test user")
+	// require.NotNil(sessionCookie, "Setup failed: Session cookie is nil")
+	// require.NotZero(userID, "Setup failed: UserID is zero")
+
+	// 1. Add a link to work with
+	addPayload := StorefrontLinkAddPayload{StoreType: "demo_flow_real", StoreName: "Real Flow Store", ApiKey: "flow_key_real", StoreId: "flow_real", StoreUrl: "http://example.com/flow_real"}
+	addBody, _ := json.Marshal(addPayload)
+	addReq := httptest.NewRequest(http.MethodPost, "/api/add_storefront", bytes.NewReader(addBody))
+	addReq.Header.Set("Content-Type", "application/json")
+	addReq.AddCookie(sessionCookie) // Authenticate
+	addRR := httptest.NewRecorder()
+	AddStorefront(addRR, addReq)
+	require.Equal(http.StatusCreated, addRR.Code, "Flow Setup: Failed to add initial link")
+	var addedLinkResp StorefrontLinkReturn
+	require.NoError(json.Unmarshal(addRR.Body.Bytes(), &addedLinkResp), "Flow Setup: Failed to parse add response") // No 't'
+	linkID := addedLinkResp.ID
+
+	// 2. Get Storefronts
+	getReq := httptest.NewRequest(http.MethodGet, "/api/get_storefronts", nil)
+	getReq.AddCookie(sessionCookie) // Authenticate
+	getRR := httptest.NewRecorder()
+	GetStorefronts(getRR, getReq)
+	require.Equal(http.StatusOK, getRR.Code, "Flow Get: Failed status")
+	var links []StorefrontLinkReturn
+	require.NoError(json.Unmarshal(getRR.Body.Bytes(), &links), "Flow Get: Failed to parse list") // No 't'
+	// ... (Verify link presence as before) ...
+	found := false
+	for _, link := range links {
+		if link.ID == linkID {
+			assert.Equal(addPayload.StoreName, link.StoreName)
+			found = true
+			break
+		}
+	}
+	assert.True(found, "Flow Get: Newly added link not found")
+
+	// 3. Update the link
+	updatePayload := StorefrontLinkUpdatePayload{StoreName: "Real Flow Store UPDATED", StoreId: "flow_real_upd", StoreUrl: "http://example.com/flow_real_upd"}
+	updateBody, _ := json.Marshal(updatePayload)
+	updateURL := fmt.Sprintf("/api/update_storefront?id=%d", linkID)
+	updateReq := httptest.NewRequest(http.MethodPut, updateURL, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq.AddCookie(sessionCookie) // Authenticate
+	updateRR := httptest.NewRecorder()
+	UpdateStorefront(updateRR, updateReq)
+	require.Equal(http.StatusOK, updateRR.Code, "Flow Update: Failed status")
+	var updatedLinkResp StorefrontLinkReturn                                                                          // Need this if checking response
+	require.NoError(json.Unmarshal(updateRR.Body.Bytes(), &updatedLinkResp), "Flow Update: Failed to parse response") // No 't'
+
+	// Verify update in DB
+	var updatedLinkDB StorefrontLink
+	dbResult := db.First(&updatedLinkDB, linkID)
+	require.NoError(dbResult.Error) // No 't'
+	assert.Equal(updatePayload.StoreName, updatedLinkDB.StoreName)
+	// ... (Check credentials didn't change)
+	decryptedCreds, decryptErr := decryptCredentials(updatedLinkDB.Credentials)
+	require.NoError(decryptErr)                                    // No 't'
+	origCredsMap := map[string]string{"apiKey": addPayload.ApiKey} // Reconstruct original creds map
+	origCredsJSON, _ := json.Marshal(origCredsMap)
+	assert.JSONEq(string(origCredsJSON), decryptedCreds)
+
+	// 4. Delete the link
+	deleteURL := fmt.Sprintf("/api/delete_storefront?id=%d", linkID)
+	deleteReq := httptest.NewRequest(http.MethodDelete, deleteURL, nil)
+	deleteReq.AddCookie(sessionCookie) // Authenticate
+	deleteRR := httptest.NewRecorder()
+	DeleteStorefront(deleteRR, deleteReq)
+	assert.Contains([]int{http.StatusOK, http.StatusNoContent}, deleteRR.Code, "Flow Delete: Failed status")
+	// ... (Verify deletion in DB as before) ...
+	var deletedLink StorefrontLink
+	err = db.First(&deletedLink, linkID).Error
+	assert.Error(err) // No 't' needed
+	assert.True(errors.Is(err, gorm.ErrRecordNotFound))
+}
+
+// ... TestSpecificErrors_RealLogin definition ...
+func TestSpecificErrors_RealLogin(t *testing.T) {
+	// assert := asrt.New(t)
+	require := req.New(t)
+
+	// Define Helper struct at the beginning of the function scope
+	type CheckLink struct {
+		ID uint `gorm:"primaryKey"`
+	}
+
+	// --- Setup users ---
+	password := "password123"
+	_, sessionCookie1, _ := makeTestUser(t, password)
+	_, sessionCookie2, _ := makeTestUser(t, password)
+
+	// Add a link belonging to User 1
+	addPayload := StorefrontLinkAddPayload{StoreType: "errors_real", StoreName: "Link For User 1", ApiKey: "key"}
+	addBody, _ := json.Marshal(addPayload)
+	addReq := httptest.NewRequest(http.MethodPost, "/api/add_storefront", bytes.NewReader(addBody))
+	addReq.Header.Set("Content-Type", "application/json")
+	addReq.AddCookie(sessionCookie1) // Use User 1's cookie
+	addRR := httptest.NewRecorder()
+	AddStorefront(addRR, addReq)
+	require.Equal(http.StatusCreated, addRR.Code)
+	var addedResp StorefrontLinkReturn
+	require.NoError(json.Unmarshal(addRR.Body.Bytes(), &addedResp))
+	linkIDUser1 := addedResp.ID // ID of the link owned by User 1
+
+	t.Run("UpdateForbidden", func(t *testing.T) {
+		assert := asrt.New(t) // Use subtest 't'
+
+		updatePayload := StorefrontLinkUpdatePayload{StoreName: "Attempt Update by User 2"}
+		body, _ := json.Marshal(updatePayload)
+		url := fmt.Sprintf("/api/update_storefront?id=%d", linkIDUser1) // Target User 1's link
+		req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(sessionCookie2) // Logged in as User 2
+		rr := httptest.NewRecorder()
+		UpdateStorefront(rr, req)
+		assert.Equal(http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("DeleteForbidden", func(t *testing.T) {
+		assert := asrt.New(t) // Use subtest 't'
+
+		url := fmt.Sprintf("/api/delete_storefront?id=%d", linkIDUser1) // Target User 1's link
+		req := httptest.NewRequest(http.MethodDelete, url, nil)
+		req.AddCookie(sessionCookie2) // Logged in as User 2
+		rr := httptest.NewRecorder()
+		DeleteStorefront(rr, req)
+		assert.Equal(http.StatusForbidden, rr.Code)
+
+		// Verify User 1's link still exists
+		var link CheckLink
+		err := db.Model(&StorefrontLink{}).Select("id").First(&link, linkIDUser1).Error
+		assert.NoError(err, "Link owned by User 1 should not have been deleted") // No 't' needed
+	})
+
+	t.Run("UpdateNotFound", func(t *testing.T) {
+		assert := asrt.New(t) // Use subtest 't'
+
+		nonExistentID := uint(999999)
+		updatePayload := StorefrontLinkUpdatePayload{StoreName: "Update Non Existent"}
+		body, _ := json.Marshal(updatePayload)
+		url := fmt.Sprintf("/api/update_storefront?id=%d", nonExistentID)
+		req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(sessionCookie1) // Logged in as User 1 (doesn't matter for not found)
+		rr := httptest.NewRecorder()
+		UpdateStorefront(rr, req)
+		assert.Equal(http.StatusNotFound, rr.Code)
+	})
+}

--- a/front-runner_backend/main.go
+++ b/front-runner_backend/main.go
@@ -20,6 +20,7 @@ import (
 	"front-runner/internal/login"
 	"front-runner/internal/prodtable"
 	"front-runner/internal/routes"
+	"front-runner/internal/storefronttable"
 	"front-runner/internal/usertable"
 
 	"github.com/gorilla/mux"
@@ -48,6 +49,10 @@ func setupModules() {
 	// Product Table
 	prodtable.Setup()
 	prodtable.MigrateProdDB()
+
+	// Storefront Table
+	storefronttable.Setup()
+	storefronttable.MigrateStorefrontDB()
 }
 
 func main() {


### PR DESCRIPTION
Added basic front end:
* storefront page is implemented - VERY BASIC
* Added a popup page like the products for adding a storefront
* Clicking on a storefront allows the user to edit a storefront

Added store front backend:
* Added `storefronttable.go` with: `AddStorefront()`, `GetStorefronts()`, `UpdateStorefront()`, and `DeleteStorefront()`
* Added separate encryption file for storefront api key storage
* Added storefront tests

Updated the `main.go` file and the `routes.go` file to point to the new package correctly.

Fixed prodtable and prodtable_test:
* since `UserID` and `ProdName` had "idx_product,unique" added for the values in the Product struct I had to change some code. Previously we were saving a new item on top of an old one effectively replacing it, however, the 'unique' requirement in `grom` prevents this and we had to change to explicitly updating the items

Updated generateCert.sh:
* Added a line to generate the `.storefrontkey` needed for encryption

Updated the README and the Swagger docs as well.

FOR THE FUTURE:
* In order to correctly link the store fronts we will have to implement OAuth 2.0 which requires:
  * The site needs to be hosted somewhere
  * We need to create developer accounts for all supported storefronts
  * We need to register our site in our developer accounts
  * We need to set up the token management for the OAuth (many steps here)